### PR TITLE
Match fibers

### DIFF
--- a/bin/desi_fvc_proc
+++ b/bin/desi_fvc_proc
@@ -107,6 +107,12 @@ for k in ["EXP_Q_0","EXP_S_0","PETAL_LOC","DEVICE_LOC","LOCATION"] :
         if k not in spots.keys() : spots[k] = np.zeros(len(spots))
         spots[k][selection]=expected_pos[k][indices]
 
+# for spots with metrology X_FP_EXP=X_FP_METRO
+selection = (spots["X_FP_METRO"]!=0)
+spots["X_FP_EXP"][selection]=spots["X_FP_METRO"][selection]
+selection = (spots["Y_FP_METRO"]!=0)
+spots["Y_FP_EXP"][selection]=spots["Y_FP_METRO"][selection]
+
 # write transfo
 if args.output_transform is not None :
     if not args.output_transform.endswith(".json") :

--- a/bin/desi_fvc_proc
+++ b/bin/desi_fvc_proc
@@ -13,8 +13,9 @@ from astropy.table import Table
 from desimeter.log import get_logger
 from desimeter.detectspots import detectspots
 from desimeter.findfiducials import findfiducials
-#from desimeter.transform.fvc2fp.poly2d import FVCFP_Polynomial
 from desimeter.transform.fvc2fp.zb import FVCFP_ZhaoBurge
+from desimeter.match import match
+from desimeter.transform.xy2qs import qs2xy
 
 parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                      description="""FVC image processing""")
@@ -30,6 +31,10 @@ parser.add_argument('--input-transform', type = str, default = None, required = 
                     help = 'use this json file as input for the match, defaut is data/default-fvc2fp.json')
 parser.add_argument('--threshold', type = float, default = 500., required = False,
                     help = "threshold for spots detection")
+parser.add_argument('--expected-positions', type = str, default = None, required = False,
+                    help = 'path to fits file or CSV file with fibers expected position (table column EXP_Q and EXP_S')
+parser.add_argument('--hdu-for-expected-positions', type = str, default = "DATA", required = False,
+                    help = 'specify HDU in expected position fits file')
 
 args  = parser.parse_args()
 log   = get_logger()
@@ -54,17 +59,63 @@ else :
 
 spots = findfiducials(spots,input_transform=args.input_transform)
 
-#tx = FVCFP_Polynomial()
 tx = FVCFP_ZhaoBurge()
 tx.fit(spots, update_spots=True)
-# spots = fit_fvc2fp(spots)
 
+if args.expected_positions is not None :
+    log.info("reading expected positions in {}".format(args.expected_positions))
+    expected_pos = Table.read(args.expected_positions) # auto-magically guess format
+    if not "X_FP_EXP" in expected_pos.keys() :
+        if "EXP_Q_0" in  expected_pos.keys() :
+            log.info("EXP_Q_0,EXP_S_0 -> X_FP,Y_FP")
+            x,y = qs2xy(q=expected_pos["EXP_Q_0"],s=expected_pos["EXP_S_0"])
+            expected_pos["X_FP"] = x
+            expected_pos["Y_FP"] = y
+        else :
+            log.error("No EXP_Q_0 nor X_FP in expected positions file {}".format(args.expected_positions))
+else :
+    log.info("since no input expected positions, use metrology to match the fibers to the positioner centers")
+    filename = resource_filename('desimeter',"data/fp-metrology.csv")
+    if not os.path.isfile(filename) :
+        log.error("cannot find {}".format(filename))
+        raise IOError("cannot find {}".format(filename))
+    log.info("reading metrology in {}".format(filename)) 
+    expected_pos = Table.read(filename,format="csv")
+    
+if not "LOCATION" in expected_pos.keys() :
+    # add useful location keyword
+    expected_pos["LOCATION"] = np.array(expected_pos["PETAL_LOC"])*1000+np.array(expected_pos["DEVICE_LOC"])
+
+if "PINHOLE_ID" in expected_pos.dtype.names :
+    # exclude pinhole because here we want to match fibers
+    ii = np.where(expected_pos["PINHOLE_ID"]==0)[0]
+    expected_pos = expected_pos[:][ii]
+
+# select spots that are not already matched
+selection  = (spots["LOCATION"]==0)
+# match
+indices,distances = match(expected_pos["X_FP"],expected_pos["Y_FP"],spots["X_FP"][selection],spots["Y_FP"][selection])
+for maxdist in [0.1,1,5.] :
+    log.info("Number of match < {}mm = {}/{}".format(maxdist,np.sum(distances<maxdist),len(expected_pos)))
+
+# add columns after matching fibers
+for k1,k2 in zip(["X_FP","Y_FP"],["X_FP_EXP","Y_FP_EXP"]) :
+    if k2 not in spots.keys() : spots[k2] = np.zeros(len(spots))
+    spots[k2][selection]=expected_pos[k1][indices]
+for k in ["EXP_Q_0","EXP_S_0","PETAL_LOC","DEVICE_LOC","LOCATION"] :
+    if k in expected_pos.keys() :
+        if k not in spots.keys() : spots[k] = np.zeros(len(spots))
+        spots[k][selection]=expected_pos[k][indices]
+
+# write transfo
 if args.output_transform is not None :
     if not args.output_transform.endswith(".json") :
         print("error, can only write json files, so please choose an output filename end ing with .json")
     else :
         tx.write_jsonfile(args.output_transform)
         print("wrote transform in {}".format(args.output_transform))
+
+# write spots
 spots.write(args.outfile,format="csv",overwrite=True)
 print("wrote {}".format(args.outfile))
 

--- a/bin/plot_fvc_residuals
+++ b/bin/plot_fvc_residuals
@@ -12,6 +12,8 @@ parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFo
                                      description="""Plot FVC spots, showing residuals with metrology""")
 parser.add_argument('-i','--infile', type = str, default = None, required = True,
                     help = 'path to a FVC spots table in CSV format (with X_FP,Y_FP,X_FP_METRO,Y_FP_METRO columns)')
+parser.add_argument('--expected', action = "store_true",
+                    help = 'compare with expected location (X_FP_EXP,Y_FP_EXP) instead of (X_FP_METRO,Y_FP_METRO)')
 
 args  = parser.parse_args()
 
@@ -23,11 +25,24 @@ filename = args.infile
     
 table=Table.read(filename,format="csv")
 
-ii = np.where((table["LOCATION"]>0)&(table["X_FP_METRO"]!=0))[0]
-x = table["X_FP"][ii]
-y = table["Y_FP"][ii]
-xm = table["X_FP_METRO"][ii]
-ym = table["Y_FP_METRO"][ii]
+if args.expected :
+    ii = np.where((table["LOCATION"]>0)&(table["X_FP_EXP"]!=0))[0]
+    if ii.size == 0 :
+        print("empty selection")
+        sys.exit(12)
+    x = table["X_FP"][ii]
+    y = table["Y_FP"][ii]
+    xm = table["X_FP_EXP"][ii]
+    ym = table["Y_FP_EXP"][ii]
+else :
+    ii = np.where((table["LOCATION"]>0)&(table["X_FP_METRO"]!=0))[0]
+    if ii.size == 0 :
+        print("empty selection")
+        sys.exit(12)
+    x = table["X_FP"][ii]
+    y = table["Y_FP"][ii]
+    xm = table["X_FP_METRO"][ii]
+    ym = table["Y_FP_METRO"][ii]
 
 fig = plt.figure(figsize=(6,6))
 
@@ -36,23 +51,32 @@ a.set_title(os.path.basename(filename))
 
 a.plot(table["X_FP"],table["Y_FP"],".",alpha=0.5,label="all spots")
 
-# plotting all of FIF and GIF
-filename = resource_filename('desimeter',"data/fp-metrology.csv")
-metrology = Table.read(filename,format="csv")
-selection=(metrology["DEVICE_TYPE"]=="FIF")|(metrology["DEVICE_TYPE"]=="GIF")
-a.scatter(metrology["X_FP"][selection],metrology["Y_FP"][selection],marker="o",edgecolors="gray",alpha=1.,facecolors="none",label="all FIF and GIF metrology")
-selection=((metrology["DEVICE_TYPE"]=="FIF")|(metrology["DEVICE_TYPE"]=="GIF"))&(metrology["PINHOLE_ID"]==4)
-a.scatter(metrology["X_FP"][selection],metrology["Y_FP"][selection],marker="o",edgecolors="black",alpha=1.,facecolors="none",label="central pinhole #4")
+if not args.expected : # plotting match to fiducials 
+    # plotting all of FIF and GIF
+    filename = resource_filename('desimeter',"data/fp-metrology.csv")
+    metrology = Table.read(filename,format="csv")
+    selection=(metrology["DEVICE_TYPE"]=="FIF")|(metrology["DEVICE_TYPE"]=="GIF")
+    a.scatter(metrology["X_FP"][selection],metrology["Y_FP"][selection],marker="o",edgecolors="gray",alpha=1.,facecolors="none",label="all FIF and GIF metrology")
+    selection=((metrology["DEVICE_TYPE"]=="FIF")|(metrology["DEVICE_TYPE"]=="GIF"))&(metrology["PINHOLE_ID"]==4)
+    a.scatter(metrology["X_FP"][selection],metrology["Y_FP"][selection],marker="o",edgecolors="black",alpha=1.,facecolors="none",label="central pinhole #4")
 
 a.plot(x,y,".",color="purple",label="matched measured spots")
-a.scatter(xm,ym,marker="o",edgecolors="orange",facecolors="none",label="matched metrology")
-
+if args.expected :
+    label = "matched expected positions"
+    marker = "."
+else :
+    label = "matched metrology"
+    marker = "o"
+a.scatter(xm,ym,marker=marker,edgecolors="orange",facecolors="none",label=label)
+    
 dx=xm-x
 dy=ym-y
 
 
 jj=np.where((np.abs(dx)>0.1)|(np.abs(dy)>0.1))[0]
-if jj.size > 0 : # sadly
+if jj.size>100 :
+    print("a lot of large residuals:",jj.size)
+elif jj.size > 0 : # sadly
     print("Large residuals")
     for j in jj :
         i=ii[j]

--- a/py/desimeter/findfiducials.py
+++ b/py/desimeter/findfiducials.py
@@ -271,6 +271,8 @@ def findfiducials(spots,input_transform=None,separation=7.) :
             plt.show()
             sys.exit(12)
             """
+    spots["PETAL_LOC"]=spots["LOCATION"]//1000
+    spots["DEVICE_LOC"]=spots["LOCATION"]%1000
     
     n_matched_pinholes  = np.sum(spots["PINHOLE_ID"]>0)
     n_matched_fiducials = np.sum(spots["PINHOLE_ID"]==4)

--- a/py/desimeter/match.py
+++ b/py/desimeter/match.py
@@ -1,0 +1,19 @@
+"""
+Utility functions to match in a list of spots given a list of expected fiber positions 
+in the FP frame (after match of fiducials and fit of transform)
+"""
+
+
+import numpy as np
+from scipy.spatial import cKDTree as KDTree
+
+def match(x1,y1,x2,y2) :
+    """
+    match two catalogs, assuming in the same coordinate system (no transfo)
+    """
+    xy1=np.array([x1,y1]).T
+    xy2=np.array([x2,y2]).T
+    tree1 = KDTree(xy1)
+    distances,indices1 = tree1.query(xy2,k=1)
+    return indices1,distances
+

--- a/py/desimeter/transform/xy2qs.py
+++ b/py/desimeter/transform/xy2qs.py
@@ -1,0 +1,50 @@
+import numpy as np
+
+def xy2qs(x, y):
+    '''Focal tangent plane x,y -> angular q,s on curved focal surface
+
+    Args:
+        x, y: cartesian location on focal tangent plane in mm
+
+    Returns (q, s) where q=angle in degrees; s=focal surface radial dist [mm]
+
+    Notes: (x,y) are in the "CS5" DESI coordinate system tangent plane to
+    the curved focal surface.  q is the radial angle measured counter-clockwise
+    from the x-axis; s is the radial distance along the curved focal surface;
+    it is *not* sqrt(x**2 + y**2).  (q,s) are the preferred coordinates for
+    the DESI focal plane hardware engineering team.
+    '''
+    # fitted on desimodel/data/focalplane/fiberpos.ecsv
+    # residuals are < 0.4 microns
+    c   = np.array([-3.01232440e-03,  1.45324708e-02, -2.55244612e-02,  2.15885180e-02, -8.05287872e-03,  2.05529419e-03,  9.99773920e-01,  9.12275165e-06])
+    pol = np.poly1d(c)
+    r   = np.sqrt(x**2 + y**2)
+    s   = 400.*pol(r/400.)
+    q = (np.degrees(np.arctan2(y, x)) + 360.0) % 360.0
+    return q, s
+
+def qs2xy(q, s):
+    '''angular q,s on curved focal surface -> focal tangent plane x,y
+
+    Args:
+        q: angle in degrees
+        s: focal surface radial distance in mm
+
+    Returns (x, y) cartesian location on focal tangent plane in mm
+
+    Notes: (x,y) are in the "CS5" DESI coordinate system tangent plane to
+    the curved focal surface.  q is the radial angle measured counter-clockwise
+    from the x-axis; s is the radial distance along the curved focal surface;
+    it is *not* sqrt(x**2 + y**2).  (q,s) are the preferred coordinates for
+    the DESI focal plane hardware engineering team.
+    '''
+
+    # fitted on desimodel/data/focalplane/fiberpos.ecsv
+    # residuals are < 0.4 microns
+    c   = np.array([-2.60833797e-03,  6.40671681e-03, -5.64913181e-03,  6.99354170e-04, -2.13171265e-04,  1.00000009e+00,  9.75790364e-07])
+    pol = np.poly1d(c)
+    r   = 400.*pol(s/400.)
+    x = r*np.cos(np.radians(q))
+    y = r*np.sin(np.radians(q))
+
+    return x, y


### PR DESCRIPTION
Add code to match the fibers, either to the expected positions (from an input coordinates-xxx.fits table from Klaus for instance), or to the  positioner centers metrology.

Example
```desi_fvc_proc -i /project/projectdirs/desi/spectro/data/20191231/00037096/fvc-00037096.fits.fz --expected /project/projectdirs/desi/spectro/data/20191231/00037096/coordinates-00037096.fits -o out.csv```
