### PR TITLE
gfa2fp transforms

### DIFF
--- a/py/desimeter/io.py
+++ b/py/desimeter/io.py
@@ -1,0 +1,10 @@
+from pkg_resources import resource_filename
+from astropy.table import Table
+
+def load_metrology():
+    '''
+    Returns metrology table
+    '''
+    filename = resource_filename('desimeter', 'data/fp-metrology.csv')
+    metrology = Table.read(filename)
+    return metrology

--- a/py/desimeter/test/test_gfa2fp.py
+++ b/py/desimeter/test/test_gfa2fp.py
@@ -1,0 +1,66 @@
+import unittest
+from pkg_resources import resource_filename
+
+import numpy as np
+
+from desimeter.transform.gfa2fp import (
+    apply_scale_rotation_offset, undo_scale_rotation_offset)
+from desimeter.transform.gfa2fp import gfa2fp, fp2gfa
+from desimeter import io
+
+class TestTan2FP(unittest.TestCase):
+
+    def test_gfa2fp(self):
+        metrology = io.load_metrology()
+        ii = (metrology['DEVICE_TYPE'] == 'GFA')
+        metrology = metrology[ii]
+        
+        nx, ny = 2048, 1032
+        xgfa_ref = np.array([0, nx-1, nx-1, 0])
+        ygfa_ref = np.array([0, 0, ny-1, ny-1])
+        
+        for p in range(10):
+            ii = (metrology['PETAL_LOC'] == p)
+            if np.count_nonzero(ii) == 0:
+                print('ERROR: missing GFA metrology for PETAL_LOC {}'.format(p))
+                continue
+            
+            xfp = np.asarray(metrology['X_FP'][ii])
+            yfp = np.asarray(metrology['Y_FP'][ii])
+            
+            xgfa, ygfa = fp2gfa(p, xfp, yfp)
+
+    def test_scale_rotation_offset(self):
+        x1 = np.array([1.0, 2.0, 3.0, 4.0])
+        y1 = np.array([2.0, 4.0, 3.0, 1.0])
+        xoff = -1.0
+        yoff = 2
+        scale = 1.3
+        rotation = 20
+
+        #- Test round trip accuracy
+        xx, yy = apply_scale_rotation_offset(x1, y1, scale, rotation, xoff, yoff)
+        x2, y2 = undo_scale_rotation_offset(xx, yy, scale, rotation, xoff, yoff)
+        
+        self.assertTrue(np.allclose(x1, x2))
+        self.assertTrue(np.allclose(y1, y2))
+        
+        #- Test scalar input
+        xx, yy = apply_scale_rotation_offset(1.0, 2.0, scale, rotation, xoff, yoff)
+        self.assertTrue(np.isscalar(xx))
+        self.assertTrue(np.isscalar(yy))
+        xx, yy = undo_scale_rotation_offset(1.0, 2.0, scale, rotation, xoff, yoff)
+        self.assertTrue(np.isscalar(xx))
+        self.assertTrue(np.isscalar(yy))
+
+        #- Test non-array list
+        xx, yy = apply_scale_rotation_offset([1.0, 2.0], [2, 3], scale, rotation, xoff, yoff)
+        self.assertEqual(len(xx), 2)
+        self.assertEqual(len(yy), 2)
+
+        xx, yy = undo_scale_rotation_offset([1.0, 2.0], [2, 3], scale, rotation, xoff, yoff)
+        self.assertEqual(len(xx), 2)
+        self.assertEqual(len(yy), 2)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/py/desimeter/test/test_gfa2fp.py
+++ b/py/desimeter/test/test_gfa2fp.py
@@ -16,8 +16,8 @@ class TestTan2FP(unittest.TestCase):
         metrology = metrology[ii]
         
         nx, ny = 2048, 1032
-        xgfa_ref = np.array([0, nx-1, nx-1, 0])
-        ygfa_ref = np.array([0, 0, ny-1, ny-1])
+        xgfa_ref = np.array([0.0, nx-1, nx-1, 0])
+        ygfa_ref = np.array([0.0, 0, ny-1, ny-1])
         
         for p in range(10):
             ii = (metrology['PETAL_LOC'] == p)
@@ -25,16 +25,32 @@ class TestTan2FP(unittest.TestCase):
                 print('ERROR: missing GFA metrology for PETAL_LOC {}'.format(p))
                 continue
             
-            xfp = np.asarray(metrology['X_FP'][ii])
-            yfp = np.asarray(metrology['Y_FP'][ii])
+            xfp_ref = np.asarray(metrology['X_FP'][ii])
+            yfp_ref = np.asarray(metrology['Y_FP'][ii])
             
-            xgfa, ygfa = fp2gfa(p, xfp, yfp)
+            #- Current agreement is not very good, because the GFA metrology
+            #- is rectangular in 3D space but these transforms are treating
+            #- them as rectangular in 2D space.
+
+            xgfa, ygfa = fp2gfa(p, xfp_ref, yfp_ref)
+            self.assertLess(np.max(np.abs(xgfa-xgfa_ref)), 2)
+            self.assertLess(np.max(np.abs(ygfa-ygfa_ref)), 2)
             
-            if p == 0:
-                #--- DEBUG ---
-                import IPython
-                IPython.embed()
-                #--- DEBUG ---
+            xfp, yfp = gfa2fp(p, xgfa_ref, ygfa_ref)            
+            dxfp = xfp-xfp_ref
+            dyfp = yfp-yfp_ref
+            self.assertLess(np.max(np.abs(dxfp)), 0.050)
+            self.assertLess(np.max(np.abs(dyfp)), 0.050)
+
+            drfp = 1000*np.sqrt(dxfp**2 + dyfp**2)
+            print('PETAL_LOC {} GFA corner max(dr) = {:.1f} um'.format(
+                p, np.max(drfp)))
+        
+        #- Round trip tests should be rock solid though
+        xfp, yfp = gfa2fp(0, xgfa_ref, ygfa_ref)
+        xgfa, ygfa = fp2gfa(0, xfp, yfp)
+        self.assertTrue(np.allclose(xgfa, xgfa_ref))
+        self.assertTrue(np.allclose(ygfa, ygfa_ref))
 
     def test_scale_rotation_offset(self):
         x1 = np.array([1.0, 2.0, 3.0, 4.0])

--- a/py/desimeter/test/test_gfa2fp.py
+++ b/py/desimeter/test/test_gfa2fp.py
@@ -29,6 +29,12 @@ class TestTan2FP(unittest.TestCase):
             yfp = np.asarray(metrology['Y_FP'][ii])
             
             xgfa, ygfa = fp2gfa(p, xfp, yfp)
+            
+            if p == 0:
+                #--- DEBUG ---
+                import IPython
+                IPython.embed()
+                #--- DEBUG ---
 
     def test_scale_rotation_offset(self):
         x1 = np.array([1.0, 2.0, 3.0, 4.0])

--- a/py/desimeter/transform/gfa2fp.py
+++ b/py/desimeter/transform/gfa2fp.py
@@ -1,0 +1,166 @@
+"""
+Transforms between GFA pixel coordinates and FP mm
+"""
+
+import numpy as np
+from scipy.optimize import minimize
+from desimeter import io
+from desimeter.log import get_logger
+
+#- Cached GFA pix -> GFA FP metrology scale, rotation, offsets per petal
+_gfa_transforms = None
+
+def gfa2fp(petal_loc, xgfa, ygfa):
+    global _gfa_transforms
+    if _gfa_transforms is None:
+        metrology = io.load_metrology()
+        _gfa_transforms = fit_gfa2fp(metrology)
+    
+    log = get_logger()
+    if petal_loc not in _gfa_transforms:
+        log.error('PETAL_LOC {} GFA metrology missing'.format(petal_loc))
+    
+    params = _gfa_transforms[petal_loc]
+    xfp, yfp = apply_scale_rotation_offset(xgfa, ygfa, **params)
+    
+    return xfp, yfp
+
+def fp2gfa(petal_loc, xfp, yfp):
+    global _gfa_transforms
+    if _gfa_transforms is None:
+        metrology = io.load_metrology()
+        _gfa_transforms = fit_gfa2fp(metrology)
+
+    log = get_logger()
+    if petal_loc not in _gfa_transforms:
+        log.error('PETAL_LOC {} GFA metrology missing'.format(petal_loc))
+    
+    params = _gfa_transforms[petal_loc]
+    xgfa, ygfa = undo_scale_rotation_offset(xfp, yfp, **params)
+    
+    return xgfa, ygfa
+
+
+#- TODO: fvc2fp has similar transforms; merge that code with this
+def apply_scale_rotation_offset(x, y, scale=1.0, rotation=0.0, xoffset=0.0, yoffset=0.0, ):
+    """
+    Convenience wrapper to return x,y transformed by offset, scale, rotation
+    
+    Args:
+        x, y (float, 1D array, or list): inputs to transform
+        xoffset, yoffset (float): offsets in same units as x,y
+        scale (float): scale factor
+        rotation (float): counter-clockwise rotation in degrees
+
+    returns xx, yy where
+        xx = scale ( x cos(rot) - y sin(rot) ) + xoffset
+        yy = scale ( x sin(rot) + y cos(rot) ) + xoffset
+    """
+    #- support lists, arrays, and scalar float -> float
+    if not np.isscalar(x):
+        x = np.asarray(x)
+    if not np.isscalar(y):
+        y = np.asarray(y)
+
+    sinrot = np.sin(np.radians(rotation))
+    cosrot = np.cos(np.radians(rotation))
+    
+    xx = scale*(x*cosrot - y*sinrot) + xoffset
+    yy = scale*(x*sinrot + y*cosrot) + yoffset
+    
+    return xx, yy
+
+def undo_scale_rotation_offset(x, y, scale=1.0, rotation=0.0, xoffset=0.0, yoffset=0.0):
+    """
+    Applies opposite transform of `apply_scale_rotation_offset``
+    
+    Args:
+        x, y (float, 1D array, or list): inputs to transform
+        xoffset, yoffset (float): offsets in same units as x,y
+        scale (float): scale factor
+        rotation (float): clockwise rotation in degrees
+
+    returns reverse-transformed x, y
+    """
+    #- support lists, arrays, and scalar float -> float
+    if not np.isscalar(x):
+        x = np.asarray(x)
+    if not np.isscalar(y):
+        y = np.asarray(y)
+    
+    x1 = (x - xoffset)/scale
+    y1 = (y - yoffset)/scale
+    sinrot = np.sin(np.radians(-rotation))
+    cosrot = np.cos(np.radians(-rotation))
+    
+    xx = (x1*cosrot - y1*sinrot)
+    yy = (x1*sinrot + y1*cosrot)
+    
+    return xx, yy
+
+def fit_scale_rotation_offset(x1, y1, x2, y2, p0=None):
+    """
+    TODO: document
+    
+    p0: starting guess (scale, rotation, xoffset, yoffset)
+    """
+    def fn(params, x1, y1, x2, y2):
+        scale, rot, xoff, yoff = params
+        xx, yy = apply_scale_rotation_offset(x1, y1, scale, rot, xoff, yoff)
+        chi2 = np.sum((xx-x2)**2 + (yy-y2)**2)
+        return chi2
+
+    x1 = np.asarray(x1)
+    x2 = np.asarray(x2)
+    y1 = np.asarray(y1)
+    y2 = np.asarray(y2)
+    
+    dx = np.mean(x1) - np.mean(x2)
+    dy = np.mean(y1) - np.mean(y2)
+
+    if p0 is None:
+        p0 = (0.015, 0.0, dx, dy)
+    results = minimize(fn, p0, args=(x1, y1, x2, y2))
+    scale, rot, xoff, yoff = results.x
+    return dict(scale=scale, rotation=rot, xoffset=xoff, yoffset=yoff)
+
+def fit_gfa2fp(metrology):
+    """
+    TODO: document
+    """
+    #- HARDCODE: GFA pixel dimensions
+    nx, ny = 2048, 1032
+
+    #- Trim to just GFA entries without altering input table
+    gfarows = (metrology['DEVICE_TYPE'] == 'GFA')
+    metrology = metrology[gfarows]
+    metrology.sort(['PETAL_LOC', 'PINHOLE_ID'])
+
+    #- Metrology corners start at (0,0) for middle of pixel
+    #- Thankfully this is consistent with gfa_reduce, desimeter fvc spots,
+    #- and the Unified Metrology Table in DESI-5421
+    xgfa = np.array([0, nx-1, nx-1, 0])
+    ygfa = np.array([0, 0, ny-1, ny-1])
+    
+    gfa_transforms = dict()
+    
+    for p in range(10):
+        ii = (metrology['PETAL_LOC'] == p)
+        if np.count_nonzero(ii) > 0:
+            xfp = np.asarray(metrology['X_FP'][ii])
+            yfp = np.asarray(metrology['Y_FP'][ii])
+            
+            #- minimization starting parameters
+            theta = np.radians(p*36 - 77)
+            rmax = 407
+            p0 = (0.015, 18+p*36.0, rmax*np.cos(theta), rmax*np.sin(theta))
+        
+            gfa_transforms[p] = fit_scale_rotation_offset(xgfa, ygfa, xfp, yfp, p0=p0)
+    
+    return gfa_transforms
+        
+        
+
+
+
+

--- a/py/desimeter/transform/gfa2fp.py
+++ b/py/desimeter/transform/gfa2fp.py
@@ -11,6 +11,15 @@ from desimeter.log import get_logger
 _gfa_transforms = None
 
 def gfa2fp(petal_loc, xgfa, ygfa):
+    """
+    Transforms from GFA pixel coordinates to focal plane mm
+
+    Args:
+        petal_loc (int): Petal location 0-9
+        xgfa, ygfa: GFA pixel coordinates, (0,0) is corner pixel center
+
+    Returns CS5 xfp, yfp in mm
+    """
     global _gfa_transforms
     if _gfa_transforms is None:
         metrology = io.load_metrology()
@@ -26,6 +35,15 @@ def gfa2fp(petal_loc, xgfa, ygfa):
     return xfp, yfp
 
 def fp2gfa(petal_loc, xfp, yfp):
+    """
+    Transforms from focal plane mm to GFA pixel coordinates
+
+    Args:
+        petal_loc (int): Petal location 0-9
+        xfp, yfp: CS5 focal plane mm
+
+    Returns xgfa, ygfa pixel coordinates with (0,0) as center of corner pixel
+    """
     global _gfa_transforms
     if _gfa_transforms is None:
         metrology = io.load_metrology()
@@ -45,7 +63,7 @@ def fp2gfa(petal_loc, xfp, yfp):
 def apply_scale_rotation_offset(x, y, scale=1.0, rotation=0.0, xoffset=0.0, yoffset=0.0, ):
     """
     Convenience wrapper to return x,y transformed by offset, scale, rotation
-    
+
     Args:
         x, y (float, 1D array, or list): inputs to transform
         xoffset, yoffset (float): offsets in same units as x,y
@@ -73,7 +91,7 @@ def apply_scale_rotation_offset(x, y, scale=1.0, rotation=0.0, xoffset=0.0, yoff
 def undo_scale_rotation_offset(x, y, scale=1.0, rotation=0.0, xoffset=0.0, yoffset=0.0):
     """
     Applies opposite transform of `apply_scale_rotation_offset``
-    
+
     Args:
         x, y (float, 1D array, or list): inputs to transform
         xoffset, yoffset (float): offsets in same units as x,y
@@ -100,9 +118,18 @@ def undo_scale_rotation_offset(x, y, scale=1.0, rotation=0.0, xoffset=0.0, yoffs
 
 def fit_scale_rotation_offset(x1, y1, x2, y2, p0=None):
     """
-    TODO: document
-    
-    p0: starting guess (scale, rotation, xoffset, yoffset)
+    Fits scale, rotation, offsets to transform (x1,y1) -> (x2,y2)
+
+    Args:
+        x1, y1: arrays of coordinates
+        x2, y2: arrays of coordinates
+
+    Options:
+        p0: starting guess (scale, rotation, xoffset, yoffset)
+
+    Returns dict(scale, rotation, xoffset, yoffset)
+
+    See `apply_scale_rotation_offset` for order of operations
     """
     def fn(params, x1, y1, x2, y2):
         scale, rot, xoff, yoff = params
@@ -126,7 +153,9 @@ def fit_scale_rotation_offset(x1, y1, x2, y2, p0=None):
 
 def fit_gfa2fp(metrology):
     """
-    TODO: document
+    Fit GFA pix -> FP mm scale, rotation, xyoffsets for each GFA
+
+    Returns dict keyed by PETAL_LOC, with dictionaries of transform coeffs.
     """
     #- HARDCODE: GFA pixel dimensions
     nx, ny = 2048, 1032


### PR DESCRIPTION
Provides transforms between GFA pixel coordinates and focal plane mm.  This version is only accurate to ~30 microns because it treats the GFA metrology as rectangular in 2D x,y when in fact the metrology is slightly tilted and they are rectangular in 3D but not 2D.  Discussed with @julienguy and @schlafly and propose to merge anyway to make progress on plumbing.  Will open a 3D ticket for followup work.