### PR TITLE
Add option to use last extension of FVC file.

### DIFF
--- a/bin/desi_fvc_proc
+++ b/bin/desi_fvc_proc
@@ -53,17 +53,15 @@ if filename.find(".fits")>0 :
         elif args.extname.strip() != 'last':
             image = fx[args.extname].read().astype(float)
         else:
-            # assumes extension ordering...
-            image = fx[len(fx)-2].read().astype(float)
-            extname = fx[len(fx)-2].get_extname()
-            try:
-                framenum = int(extname[1:])
-            except:
-                raise ValueError(f'unexpected extname: {extname}')
-            if extname[0] != 'F':
-                raise ValueError(f'unexpected extname: {extname}')
-            log.info(f'Using extension {extname}...')
-
+            extnames = [k for k in fx.hdu_map.keys() if isinstance(k, str)]
+            extnames = [e.lower() for e in extnames]
+            extname = None
+            for i in range(len(extnames)):
+                extname0 = f'f{i:04d}'
+                if extname0 in extnames:
+                    extname = extname0
+            image = fx[extname].read().astype(float)
+            log.info(f'using extension {extname}...')
     spots = detectspots(image,threshold=args.threshold,nsig=7)
 elif filename.find(".csv")>0 :
     log.info("read CSV spots table")

--- a/bin/desi_fvc_proc
+++ b/bin/desi_fvc_proc
@@ -25,7 +25,7 @@ parser.add_argument('-i','--infile', type = str, default = None, required = True
 parser.add_argument('-o','--outfile', type = str, default = None, required = True,
                     help = 'path to output CSV ASCII file')
 parser.add_argument('--extname', type = str, default = 'F0000', required = False,
-                    help = 'input EXTNAME to use if more than one HDU')
+                    help = 'input EXTNAME to use if more than one HDU; last for last HDU')
 parser.add_argument('--output-transform', type = str, default = None, required = False,
                     help = 'write transformation to this json file')
 parser.add_argument('--input-transform', type = str, default = None, required = False,
@@ -50,8 +50,19 @@ if filename.find(".fits")>0 :
     with fitsio.FITS(args.infile) as fx:
         if len(fx) == 1:
             image = fx[0].read().astype(float)
-        else:
+        elif args.extname.strip() != 'last':
             image = fx[args.extname].read().astype(float)
+        else:
+            # assumes extension ordering...
+            image = fx[len(fx)-2].read().astype(float)
+            extname = fx[len(fx)-2].get_extname()
+            try:
+                framenum = int(extname[1:])
+            except:
+                raise ValueError(f'unexpected extname: {extname}')
+            if extname[0] != 'F':
+                raise ValueError(f'unexpected extname: {extname}')
+            log.info(f'Using extension {extname}...')
 
     spots = detectspots(image,threshold=args.threshold,nsig=7)
 elif filename.find(".csv")>0 :


### PR DESCRIPTION
This PR adds support for using the last (actually, second-to-last; we don't want the C0003 extension) extension of an FVC file.

It _does_ assume an extension ordering.  I didn't want to read in all of the extension names and parse which one was the "last" one.  That may not be the desired approach.