### PR TITLE
Fail more gracefully if very few fiducials are detected.

### DIFF
--- a/bin/desi_fvc_proc
+++ b/bin/desi_fvc_proc
@@ -72,6 +72,12 @@ else :
 
 
 spots = findfiducials(spots,input_transform=args.input_transform)
+n_matched_pinholes = np.sum(spots['PINHOLE_ID'] > 0)
+n_matched_fiducials = np.sum(spots['PINHOLE_ID'] == 4)
+if n_matched_fiducials < 3:
+    log.error('Fewer than three matched fiducials; exiting early.')
+    sys.exit(13)
+
 
 tx = FVCFP_ZhaoBurge()
 tx.fit(spots, update_spots=True)


### PR DESCRIPTION
This commit sends an error message and does sys.exit(13) if fewer than 3 fiducials are detected.  In at least the case of one successful and one garbage image, this did the right thing.

I picked exit code 13 since the only other failure exit code was 12.  Those aren't typical exit codes in my experience, though, so I'm not sure this is what was desired.