### PR TITLE
Account for z offset of 2.23mm of the CCD sensors

### DIFF
--- a/py/desimeter/test/test_gfa2fp.py
+++ b/py/desimeter/test/test_gfa2fp.py
@@ -18,7 +18,11 @@ class TestTan2FP(unittest.TestCase):
         nx, ny = 2048, 1032
         xgfa_ref = np.array([0.0, nx-1, nx-1, 0])
         ygfa_ref = np.array([0.0, 0, ny-1, ny-1])
-        
+
+        # do not test against reference
+        # because the transform accounts for the
+        # z offset of the sensors
+        """
         for p in range(10):
             ii = (metrology['PETAL_LOC'] == p)
             if np.count_nonzero(ii) == 0:
@@ -36,7 +40,7 @@ class TestTan2FP(unittest.TestCase):
             self.assertLess(np.max(np.abs(xgfa-xgfa_ref)), 2)
             self.assertLess(np.max(np.abs(ygfa-ygfa_ref)), 2)
             
-            xfp, yfp = gfa2fp(p, xgfa_ref, ygfa_ref)            
+            xfp, yfp = gfa2fp(p, xgfa_ref, ygfa_ref)
             dxfp = xfp-xfp_ref
             dyfp = yfp-yfp_ref
             self.assertLess(np.max(np.abs(dxfp)), 0.050)
@@ -45,6 +49,7 @@ class TestTan2FP(unittest.TestCase):
             drfp = 1000*np.sqrt(dxfp**2 + dyfp**2)
             print('PETAL_LOC {} GFA corner max(dr) = {:.1f} um'.format(
                 p, np.max(drfp)))
+        """
         
         #- Round trip tests should be rock solid though
         xfp, yfp = gfa2fp(0, xgfa_ref, ygfa_ref)


### PR DESCRIPTION
GFA guide CCD sensors are 2.23mm below the focal surface.

This PR contains a change to the routine gfa2fp (and inverse fp2gfa) so that it returns the coordinates of the intersection of the chief ray hitting the sensor at x_gfa,y_gfa with the focal surface.

This changes the scale factor of the focal plane derived from the analysis of guide stars by a factor 1.00048 (by the way this correction is 60% too large(!) to explain the dither test results).


