### PR TITLE
gfa2fp improvement

### DIFF
--- a/py/desimeter/simplecorr.py
+++ b/py/desimeter/simplecorr.py
@@ -115,3 +115,12 @@ class SimpleCorr(object):
         xy=scale_matrix.dot(rot_matrix.dot(np.array([x,y])))
         return xy[0]+self.dx,xy[1]+self.dy
   
+    def apply_inverse(self,x,y) :
+        det = self.sxx*self.syy - self.sxy**2
+        scale_matrix = np.array([[self.syy,-self.sxy],[-self.sxy,self.sxx]])/det
+        ca=np.cos(self.rot_deg/180*np.pi)
+        sa=np.sin(self.rot_deg/180*np.pi)
+        rot_matrix = np.array([[ca,sa],[-sa,ca]])
+        xy=rot_matrix.dot(scale_matrix.dot(np.array([x-self.dx,y-self.dy])))
+        return xy[0],xy[1]
+

--- a/py/desimeter/test/test_corr.py
+++ b/py/desimeter/test/test_corr.py
@@ -14,9 +14,10 @@ class TestCorr(unittest.TestCase):
         y1=np.random.uniform(size=nn)-0.5
         
         # arb. dilatation
-        scale = 12.
-        x3 = scale*x1
-        y3 = scale*y1
+        xscale = 12.
+        yscale = 13.
+        x3 = xscale*x1
+        y3 = yscale*y1
         # arb. translation
         x3 += 33.
         y3 += 11.
@@ -26,9 +27,14 @@ class TestCorr(unittest.TestCase):
         x3b,y3b=corr31.apply(x3,y3)
         
         dist=np.sqrt((x3b-x1)**2+(y3b-y1)**2)
-        print(dist)
         assert(np.all(dist<1e-6))
-        
+
+        print("Testing inverse")
+        x1b,y1b=corr31.apply_inverse(x1,y1)
+
+        dist=np.sqrt((x1b-x3)**2+(y1b-y3)**2)
+        assert(np.all(dist<1e-6))
+
         
 if __name__ == '__main__':
     unittest.main()

--- a/py/desimeter/test/test_gfa2fp.py
+++ b/py/desimeter/test/test_gfa2fp.py
@@ -2,9 +2,6 @@ import unittest
 from pkg_resources import resource_filename
 
 import numpy as np
-
-from desimeter.transform.gfa2fp import (
-    apply_scale_rotation_offset, undo_scale_rotation_offset)
 from desimeter.transform.gfa2fp import gfa2fp, fp2gfa
 from desimeter import io
 
@@ -56,38 +53,6 @@ class TestTan2FP(unittest.TestCase):
         xgfa, ygfa = fp2gfa(0, xfp, yfp)
         self.assertTrue(np.allclose(xgfa, xgfa_ref))
         self.assertTrue(np.allclose(ygfa, ygfa_ref))
-
-    def test_scale_rotation_offset(self):
-        x1 = np.array([1.0, 2.0, 3.0, 4.0])
-        y1 = np.array([2.0, 4.0, 3.0, 1.0])
-        xoff = -1.0
-        yoff = 2
-        scale = 1.3
-        rotation = 20
-
-        #- Test round trip accuracy
-        xx, yy = apply_scale_rotation_offset(x1, y1, scale, rotation, xoff, yoff)
-        x2, y2 = undo_scale_rotation_offset(xx, yy, scale, rotation, xoff, yoff)
-        
-        self.assertTrue(np.allclose(x1, x2))
-        self.assertTrue(np.allclose(y1, y2))
-        
-        #- Test scalar input
-        xx, yy = apply_scale_rotation_offset(1.0, 2.0, scale, rotation, xoff, yoff)
-        self.assertTrue(np.isscalar(xx))
-        self.assertTrue(np.isscalar(yy))
-        xx, yy = undo_scale_rotation_offset(1.0, 2.0, scale, rotation, xoff, yoff)
-        self.assertTrue(np.isscalar(xx))
-        self.assertTrue(np.isscalar(yy))
-
-        #- Test non-array list
-        xx, yy = apply_scale_rotation_offset([1.0, 2.0], [2, 3], scale, rotation, xoff, yoff)
-        self.assertEqual(len(xx), 2)
-        self.assertEqual(len(yy), 2)
-
-        xx, yy = undo_scale_rotation_offset([1.0, 2.0], [2, 3], scale, rotation, xoff, yoff)
-        self.assertEqual(len(xx), 2)
-        self.assertEqual(len(yy), 2)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Use simplecorr transform that has 6 parameters (2 offsets, 1 rotation, 3 scales) instead of the transform that was implemented (only 1 scale). 
 - This improves the fit because of projection effects. 
 - It reduces residuals to guide stars from 0.28 arcsec to 0.17 arcsec with 116 stars in exposure 47768.
 - It's also less code.

