### PR TITLE
Fit circles

### DIFF
--- a/bin/desi_fit_circles
+++ b/bin/desi_fit_circles
@@ -3,14 +3,88 @@
 import sys
 from astropy.table import Table
 import numpy as np
+from scipy import optimize
 import matplotlib.pyplot as plt
 import argparse
 
-def fit_circle(x,y) :
+# from desimeter.transform.xy2qs import xy2qs, qs2xy
+from desimodel.focalplane import xy2qs, qs2xy
+
+#- Transform between CS5 x,y and curved focal surface
+def xy2uv(x, y):
+    q, s = xy2qs(x, y)
+    qrad = np.radians(q)
+    u = s*np.cos(qrad)
+    v = s*np.sin(qrad)
+    return u, v
+
+def uv2xy(u, v):
+    s = np.sqrt(u**2 + v**2)
+    qrad = np.arctan2(v, u)
+    q = np.degrees(qrad)
+    x, y = qs2xy(q, s)
+    return x, y
+
+#- Least squares fit to circle; adapted from "Method 2b" in
+#- https://scipy-cookbook.readthedocs.io/items/Least_Squares_Circle.html
+
+def fit_circle(xin, yin):
+
+    #- Transform to curved focal surface which is closer to a real circle
+    x, y = xy2uv(xin, yin)
+    x_m, y_m, r = fast_fit_circle(x, y)
+    
+    #- If r is too small or too big then either this positioner wasn't moving
+    #- or the points are mismatched for a bad fit.
+    if (r < 1.0) or (r > 5.0):
+        raise ValueError('Bad circle fit')
+
+    def calc_R(xc, yc):
+        """ calculate the distance of each data points from the center (xc, yc) """
+        return np.sqrt((x-xc)**2 + (y-yc)**2)
+
+    def f_2b(c):
+        """ calculate the algebraic distance between the 2D points and the mean circle centered at c=(xc, yc) """
+        Ri = calc_R(*c)
+        return Ri - Ri.mean()
+
+    def Df_2b(c):
+        """ Jacobian of f_2b
+        The axis corresponding to derivatives must be coherent with the col_deriv option of leastsq"""
+        xc, yc     = c
+        df2b_dc    = np.empty((len(c), x.size))
+
+        Ri = calc_R(xc, yc)
+        df2b_dc[0] = (xc - x)/Ri                   # dR/dxc
+        df2b_dc[1] = (yc - y)/Ri                   # dR/dyc
+        df2b_dc    = df2b_dc - df2b_dc.mean(axis=1)[:, np.newaxis]
+
+        return df2b_dc
+
+    
+    center_estimate = x_m, y_m
+    center_2b, ier = optimize.leastsq(f_2b, center_estimate, Dfun=Df_2b, col_deriv=True)
+
+    xc_2b, yc_2b = center_2b
+    Ri_2b        = calc_R(*center_2b)
+    R_2b         = Ri_2b.mean()
+    residu_2b    = sum((Ri_2b - R_2b)**2)
+
+    if (R_2b < 1.0) or (R_2b > 5.0):
+        raise ValueError('Bad circle fit')
+
+    #- Convert center back into CS5 x,y
+    xc, yc = uv2xy(xc_2b, yc_2b)
+    # xc, yc = xc_2b, yc_2b
+
+    return xc, yc, R_2b
+
+def fast_fit_circle(x,y) :
     # init
     nn=len(x)
     i1=np.arange(nn)
-    i2=(i1+1)%nn
+    ### i2=(i1+1)%nn
+    i2=(i1+nn//2-1)%nn
     
     # midpoints
     mx=((x[i1]+x[i2])/2.)
@@ -33,12 +107,6 @@ def fit_circle(x,y) :
     xc=np.mean(xc)
     yc=np.mean(yc)
     r=np.mean(np.sqrt((x-xc)**2+(y-yc)**2))
-
-    #theta=np.linspace(0,2*np.pi,200)
-    #plt.plot(xc,yc,"+",c="green")
-    #plt.plot(r*np.cos(theta)+xc,r*np.sin(theta)+yc,c="green")
-
-    # would need to refine this with chi2 minimization fit
    
     return xc,yc,r
 
@@ -54,14 +122,17 @@ parser.add_argument('--plot', action = 'store_true',
 
 args  = parser.parse_args()
 
+nmaxplot=100
+
 x={}
 y={}
 xexp={}
 yexp={}
 first=True
 for filename in args.infile :
+    print(filename)
     t=Table.read(filename)
-    print(t.dtype.names)
+    #print(t.dtype.names)
     selection=(t["PINHOLE_ID"]==0)&(t["LOCATION"]>0)
     if first :
         for loc in t["LOCATION"][selection] :
@@ -69,7 +140,7 @@ for filename in args.infile :
             y[loc] = []
             xexp[loc] = float(t["X_FP_EXP"][t["LOCATION"]==loc][0])
             yexp[loc] = float(t["Y_FP_EXP"][t["LOCATION"]==loc][0])
-            print(loc,xexp[loc],yexp[loc])
+            #print(loc,xexp[loc],yexp[loc])
         first=False
 
     for loc in t["LOCATION"][selection] :
@@ -87,6 +158,10 @@ for filename in args.infile :
         x[loc].append(float(t["X_FP"][i]))
         y[loc].append(float(t["Y_FP"][i]))
 
+
+print("number of positioners:",len(x.keys()))
+
+        
 theta=np.linspace(0,2*np.pi,50)
 
 locs=[]
@@ -94,16 +169,38 @@ x1=[]
 y1=[]
 x2=[]
 y2=[]
-for count,loc in enumerate(x.keys()) :
+count=0
+for iloc,loc in enumerate(x.keys()) :
     if len(x[loc])<6 : continue
     x[loc]=np.array(x[loc])
     y[loc]=np.array(y[loc])
+    ii=np.where(x[loc]!=0)[0]
+    x[loc]=x[loc][ii]
+    y[loc]=y[loc][ii]
+    
+    #print("{} nmeas={} rms(x)={} rms(y)={}".format(loc,ii.size,np.std(x[loc]),np.std(y[loc])))
+    
+    if np.std(x[loc])<1. :
+        if args.plot and count<nmaxplot :
+            plt.figure("circles")
+            plt.plot(np.mean(x[loc]),np.mean(y[loc]),"x",color="k",markersize=12)
+        continue
+    count += 1
+    
+    mx=np.median(x[loc])
+    my=np.median(y[loc])
     # here is the fit
-    xc,yc,r = fit_circle(x[loc],y[loc])
-    if r<0.1 : continue
-    print(loc,r)
+    try:
+        xc,yc,r = fit_circle(x[loc],y[loc])
+    except ValueError:
+        print("fit circle failed for loc={} x={} y={}".format(loc,mx,my))
+        continue
 
-    if args.plot and count < 40 :
+    if iloc%100==0 :
+        print("{}/{} loc={} x={} y={} r={}".format(iloc,len(x),loc,mx,my,r))
+    if r<0.1 : continue
+    
+    if args.plot and count<nmaxplot :
         plt.figure("circles")
         plt.plot(x[loc],y[loc],"o")
         plt.plot(xexp[loc],yexp[loc],"x")
@@ -117,8 +214,6 @@ for count,loc in enumerate(x.keys()) :
     x2.append(xc)
     y2.append(yc)
     locs.append(loc)
-    
-    if count>40 and args.plot : break
 
 locs=np.array(locs)
 x1=np.array(x1)
@@ -137,9 +232,10 @@ t2=Table([locs[ii],x1[ii],y1[ii],x2[ii],y2[ii]],names=["LOCATION","X_FP_METRO","
 t2.write(args.outfile,format="csv",overwrite=True)
 print("wrote",args.outfile)         
 
-plt.figure()
-plt.quiver(x1[ii],y1[ii],dx[ii],dy[ii])
-plt.show()
+if args.plot :
+    plt.figure(figsize=(6.1, 6))
+    plt.quiver(x1[ii],y1[ii],dx[ii],dy[ii])
+    plt.show()
 
     
 

--- a/bin/desi_fit_circles
+++ b/bin/desi_fit_circles
@@ -133,18 +133,19 @@ for filename in args.infile :
     print(filename)
     t=Table.read(filename)
     #print(t.dtype.names)
-    selection=(t["PINHOLE_ID"]==0)&(t["LOCATION"]>0)
+    selection=(t["LOCATION"]>0)
+    location_and_pinhole=(np.array(t["LOCATION"])*10+np.array(t["PINHOLE_ID"])).astype(int)
     if first :
-        for loc in t["LOCATION"][selection] :
+        for loc in location_and_pinhole[selection] :
             x[loc] = []
             y[loc] = []
-            xexp[loc] = float(t["X_FP_EXP"][t["LOCATION"]==loc][0])
-            yexp[loc] = float(t["Y_FP_EXP"][t["LOCATION"]==loc][0])
+            xexp[loc] = float(t["X_FP_EXP"][location_and_pinhole==loc][0])
+            yexp[loc] = float(t["Y_FP_EXP"][location_and_pinhole==loc][0])
             #print(loc,xexp[loc],yexp[loc])
         first=False
 
-    for loc in t["LOCATION"][selection] :
-        ii = np.where(t["LOCATION"]==loc)[0]
+    for loc in location_and_pinhole[selection] :
+        ii = np.where(location_and_pinhole==loc)[0]
         if ii.size > 1 :
             print("several matched for LOCATION ",loc)
             continue
@@ -152,23 +153,30 @@ for filename in args.infile :
         if not loc in x.keys() :
             x[loc] = []
             y[loc] = []
-            xexp[loc] = float(t["X_FP_EXP"][t["LOCATION"]==loc][0])
-            yexp[loc] = float(t["Y_FP_EXP"][t["LOCATION"]==loc][0])
+            xexp[loc] = float(t["X_FP_EXP"][location_and_pinhole==loc][0])
+            yexp[loc] = float(t["Y_FP_EXP"][location_and_pinhole==loc][0])
             
         x[loc].append(float(t["X_FP"][i]))
         y[loc].append(float(t["Y_FP"][i]))
 
+location_and_pinhole=np.array(list(x.keys()),dtype=int)
+location=location_and_pinhole//10
+pinhole=location_and_pinhole%10
+print("number of positioners:",np.sum(pinhole==0))
+print("number of fiducials:",np.sum(pinhole==1))
+print("number of pinholes:",np.sum(pinhole>=1))
 
-print("number of positioners:",len(x.keys()))
-
+ndots=len(location_and_pinhole)
         
 theta=np.linspace(0,2*np.pi,50)
 
-locs=[]
-x1=[]
-y1=[]
-x2=[]
-y2=[]
+
+xfp_metro=np.zeros(ndots)
+yfp_metro=np.zeros(ndots)
+xfp_meas=np.zeros(ndots)
+yfp_meas=np.zeros(ndots)
+
+
 count=0
 for iloc,loc in enumerate(x.keys()) :
     if len(x[loc])<6 : continue
@@ -180,61 +188,60 @@ for iloc,loc in enumerate(x.keys()) :
     
     #print("{} nmeas={} rms(x)={} rms(y)={}".format(loc,ii.size,np.std(x[loc]),np.std(y[loc])))
     
-    if np.std(x[loc])<1. :
-        if args.plot and count<nmaxplot :
+    if pinhole[iloc] == 0 and np.std(x[loc])<1. :
+        # this is a non-moving positioner, I don't use this
+        if False and args.plot and count<nmaxplot :
             plt.figure("circles")
             plt.plot(np.mean(x[loc]),np.mean(y[loc]),"x",color="k",markersize=12)
         continue
     count += 1
     
-    mx=np.median(x[loc])
-    my=np.median(y[loc])
-    # here is the fit
-    try:
-        xc,yc,r = fit_circle(x[loc],y[loc])
-    except ValueError:
-        print("fit circle failed for loc={} x={} y={}".format(loc,mx,my))
-        continue
+    xc=np.median(x[loc])
+    yc=np.median(y[loc])
 
-    if iloc%100==0 :
-        print("{}/{} loc={} x={} y={} r={}".format(iloc,len(x),loc,mx,my,r))
-    if r<0.1 : continue
+    if pinhole[iloc] == 0 : # it's a positioner
+        # here is the fit
+        try:
+            xc,yc,r = fit_circle(x[loc],y[loc])
+        except ValueError:
+            print("fit circle failed for loc={} x={} y={}".format(loc,xc,yc))
+            continue
+
+        if iloc%100==0 :
+            print("{}/{} loc={} x={} y={} r={}".format(iloc,len(x),loc,xc,yc,r))
+        if r<0.1 : continue
     
-    if args.plot and count<nmaxplot :
-        plt.figure("circles")
-        plt.plot(x[loc],y[loc],"o")
-        plt.plot(xexp[loc],yexp[loc],"x")
-        theta=np.linspace(0,2*np.pi,50)
-        plt.plot(xc+r*np.cos(theta),yc+r*np.sin(theta),"-",color="green")
-        plt.plot(xc,yc,"+",color="green")
+        if args.plot and count<nmaxplot :
+            plt.figure("circles")
+            plt.plot(x[loc],y[loc],"o")
+            plt.plot(xexp[loc],yexp[loc],"x")
+            theta=np.linspace(0,2*np.pi,50)
+            plt.plot(xc+r*np.cos(theta),yc+r*np.sin(theta),"-",color="green")
+            plt.plot(xc,yc,"+",color="green")
         
     
-    x1.append(xexp[loc])
-    y1.append(yexp[loc])
-    x2.append(xc)
-    y2.append(yc)
-    locs.append(loc)
+    xfp_metro[iloc]=xexp[loc]
+    yfp_metro[iloc]=yexp[loc]
+    xfp_meas[iloc]=xc
+    yfp_meas[iloc]=yc
 
-locs=np.array(locs)
-x1=np.array(x1)
-y1=np.array(y1)
-x2=np.array(x2)
-y2=np.array(y2)
-dx=x2-x1
-dy=y2-y1
+dx=xfp_meas-xfp_metro
+dy=yfp_meas-yfp_metro
 dr=np.sqrt(dx**2+dy**2)
-print("median offset=",np.median(dr))
-ii=np.where(dr<0.2)[0]
+print("median offset = {:4.1f} um",np.median(dr[dr!=0])*1000.)
+
+ii=np.where((xfp_metro!=0)&(dr<0.2))[0]
 
 # make a table out of that
-t2=Table([locs[ii],x1[ii],y1[ii],x2[ii],y2[ii]],names=["LOCATION","X_FP_METRO","Y_FP_METRO","X_FP_THETA_AXIS","Y_FP_THETA_AXIS"],dtype=[int,float,float,float,float])
+t2=Table([location[ii],pinhole[ii],xfp_metro[ii],yfp_metro[ii],xfp_meas[ii],yfp_meas[ii]],names=["LOCATION","PINHOLE_ID","X_FP_METRO","Y_FP_METRO","X_FP","Y_FP"],dtype=[int,int,float,float,float,float])
 
 t2.write(args.outfile,format="csv",overwrite=True)
 print("wrote",args.outfile)         
 
 if args.plot :
-    plt.figure(figsize=(6.1, 6))
-    plt.quiver(x1[ii],y1[ii],dx[ii],dy[ii])
+    plt.figure("quiver",figsize=(6.1, 6))
+    plt.quiver(xfp_meas[ii],yfp_meas[ii],dx[ii],dy[ii])
+    plt.plot(xfp_meas[ii][pinhole[ii]>0],yfp_meas[ii][pinhole[ii]>0],".",c="red")
     plt.show()
 
     

--- a/bin/desi_fit_circles
+++ b/bin/desi_fit_circles
@@ -3,99 +3,11 @@
 import sys
 from astropy.table import Table
 import numpy as np
-from scipy import optimize
 import matplotlib.pyplot as plt
 import argparse
 
-
+from desimeter.circles import fit_circle
 from desimeter.transform.xy2qs import xy2uv, uv2xy
-
-
-#- Least squares fit to circle; adapted from "Method 2b" in
-#- https://scipy-cookbook.readthedocs.io/items/Least_Squares_Circle.html
-
-def fit_circle(xin, yin):
-
-    #- Transform to curved focal surface which is closer to a real circle
-    x, y = xy2uv(xin, yin)
-    x_m, y_m, r = fast_fit_circle(x, y)
-    
-    #- If r is too small or too big then either this positioner wasn't moving
-    #- or the points are mismatched for a bad fit.
-    if (r < 1.0) or (r > 5.0):
-        raise ValueError('Bad circle fit')
-
-    def calc_R(xc, yc):
-        """ calculate the distance of each data points from the center (xc, yc) """
-        return np.sqrt((x-xc)**2 + (y-yc)**2)
-
-    def f_2b(c):
-        """ calculate the algebraic distance between the 2D points and the mean circle centered at c=(xc, yc) """
-        Ri = calc_R(*c)
-        return Ri - Ri.mean()
-
-    def Df_2b(c):
-        """ Jacobian of f_2b
-        The axis corresponding to derivatives must be coherent with the col_deriv option of leastsq"""
-        xc, yc     = c
-        df2b_dc    = np.empty((len(c), x.size))
-
-        Ri = calc_R(xc, yc)
-        df2b_dc[0] = (xc - x)/Ri                   # dR/dxc
-        df2b_dc[1] = (yc - y)/Ri                   # dR/dyc
-        df2b_dc    = df2b_dc - df2b_dc.mean(axis=1)[:, np.newaxis]
-
-        return df2b_dc
-
-    
-    center_estimate = x_m, y_m
-    center_2b, ier = optimize.leastsq(f_2b, center_estimate, Dfun=Df_2b, col_deriv=True)
-
-    xc_2b, yc_2b = center_2b
-    Ri_2b        = calc_R(*center_2b)
-    R_2b         = Ri_2b.mean()
-    residu_2b    = sum((Ri_2b - R_2b)**2)
-
-    if (R_2b < 1.0) or (R_2b > 5.0):
-        raise ValueError('Bad circle fit')
-
-    #- Convert center back into CS5 x,y
-    xc, yc = uv2xy(xc_2b, yc_2b)
-    # xc, yc = xc_2b, yc_2b
-
-    return xc, yc, R_2b
-
-def fast_fit_circle(x,y) :
-    # init
-    nn=len(x)
-    i1=np.arange(nn)
-    ### i2=(i1+1)%nn
-    i2=(i1+nn//2-1)%nn
-    
-    # midpoints
-    mx=((x[i1]+x[i2])/2.)
-    my=((y[i1]+y[i2])/2.)
-    nx=(y[i2]-y[i1])
-    ny=-(x[i2]-x[i1])
-
-    # solve for intersection of perpendicular bisectors
-    # with s1,s2 are affine parameters of 2 adjacent perpendicular bisectors
-    # 2 equations:
-    # mx1 + nx1*s1 = mx2 + nx2*s2
-    # my1 + ny1*s1 = my2 + ny2*s2
-    s1 = (ny[i2]*mx[i2]-nx[i2]*my[i2]-ny[i2]*mx[i1]+nx[i2]*my[i1])/(ny[i2]*nx[i1]-nx[i2]*ny[i1])
-
-    # coordinates of intersections are estimates of center of circle
-    xc=mx[i1]+nx[i1]*s1[i1]
-    yc=my[i1]+ny[i1]*s1[i1]
-    
-    # first estimate of center is mean of all intersections
-    xc=np.mean(xc)
-    yc=np.mean(yc)
-    r=np.mean(np.sqrt((x-xc)**2+(y-yc)**2))
-   
-    return xc,yc,r
-
 
 parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                      description="""FVC image processing""")
@@ -188,7 +100,12 @@ for iloc,loc in enumerate(x.keys()) :
     if pinhole[iloc] == 0 : # it's a positioner
         # here is the fit
         try:
-            xc,yc,r = fit_circle(x[loc],y[loc])
+            #- Transform to curved focal surface which is closer to a real circle
+            x_cfs, y_cfs = xy2uv(x[loc], y[loc])
+            #- Do the fit
+            xc_cfs,yc_cfs,r = fit_circle(x_cfs, y_cfs)
+            #- Convert center back into CS5 x,y
+            xc, yc = uv2xy(xc_cfs, yc_cfs)
         except ValueError:
             print("fit circle failed for loc={} x={} y={}".format(loc,xc,yc))
             continue

--- a/bin/desi_fit_circles
+++ b/bin/desi_fit_circles
@@ -7,23 +7,9 @@ from scipy import optimize
 import matplotlib.pyplot as plt
 import argparse
 
-# from desimeter.transform.xy2qs import xy2qs, qs2xy
-from desimodel.focalplane import xy2qs, qs2xy
 
-#- Transform between CS5 x,y and curved focal surface
-def xy2uv(x, y):
-    q, s = xy2qs(x, y)
-    qrad = np.radians(q)
-    u = s*np.cos(qrad)
-    v = s*np.sin(qrad)
-    return u, v
+from desimeter.transform.xy2qs import xy2uv, uv2xy
 
-def uv2xy(u, v):
-    s = np.sqrt(u**2 + v**2)
-    qrad = np.arctan2(v, u)
-    q = np.degrees(qrad)
-    x, y = qs2xy(q, s)
-    return x, y
 
 #- Least squares fit to circle; adapted from "Method 2b" in
 #- https://scipy-cookbook.readthedocs.io/items/Least_Squares_Circle.html

--- a/bin/desi_fit_fvc_circles
+++ b/bin/desi_fit_fvc_circles
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+
+import sys
+from astropy.table import Table
+import numpy as np
+import matplotlib.pyplot as plt
+import argparse
+
+def fit_circle(x,y) :
+    # init
+    nn=len(x)
+    i1=np.arange(nn)
+    i2=(i1+1)%nn
+    
+    # midpoints
+    mx=((x[i1]+x[i2])/2.)
+    my=((y[i1]+y[i2])/2.)
+    nx=(y[i2]-y[i1])
+    ny=-(x[i2]-x[i1])
+
+    # solve for intersection of perpendicular bisectors
+    # with s1,s2 are affine parameters of 2 adjacent perpendicular bisectors
+    # 2 equations:
+    # mx1 + nx1*s1 = mx2 + nx2*s2
+    # my1 + ny1*s1 = my2 + ny2*s2
+    s1 = (ny[i2]*mx[i2]-nx[i2]*my[i2]-ny[i2]*mx[i1]+nx[i2]*my[i1])/(ny[i2]*nx[i1]-nx[i2]*ny[i1])
+
+    # coordinates of intersections are estimates of center of circle
+    xc=mx[i1]+nx[i1]*s1[i1]
+    yc=my[i1]+ny[i1]*s1[i1]
+    
+    # first estimate of center is mean of all intersections
+    xc=np.mean(xc)
+    yc=np.mean(yc)
+    r=np.mean(np.sqrt((x-xc)**2+(y-yc)**2))
+
+    #theta=np.linspace(0,2*np.pi,200)
+    #plt.plot(xc,yc,"+",c="green")
+    #plt.plot(r*np.cos(theta)+xc,r*np.sin(theta)+yc,c="green")
+
+    # would need to refine this with chi2 minimization fit
+   
+    return xc,yc,r
+
+
+parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+                                     description="""FVC image processing""")
+parser.add_argument('-i','--infile', type = str, default = None, required = True, nargs="*",
+                    help = 'path to desimeter CSV files')
+parser.add_argument('-o','--outfile', type = str, default = None, required = True,
+                    help = 'path to output CSV ASCII file')
+parser.add_argument('--plot', action = 'store_true', 
+                    help = 'plot some circles')
+
+args  = parser.parse_args()
+
+x={}
+y={}
+xexp={}
+yexp={}
+first=True
+for filename in args.infile :
+    t=Table.read(filename)
+    print(t.dtype.names)
+    selection=(t["PINHOLE_ID"]==0)&(t["LOCATION"]>0)
+    if first :
+        for loc in t["LOCATION"][selection] :
+            x[loc] = []
+            y[loc] = []
+            xexp[loc] = float(t["X_FP_EXP"][t["LOCATION"]==loc][0])
+            yexp[loc] = float(t["Y_FP_EXP"][t["LOCATION"]==loc][0])
+            print(loc,xexp[loc],yexp[loc])
+        first=False
+
+    for loc in t["LOCATION"][selection] :
+        ii = np.where(t["LOCATION"]==loc)[0]
+        if ii.size > 1 :
+            print("several matched for LOCATION ",loc)
+            continue
+        i=ii[0]
+        if not loc in x.keys() :
+            x[loc] = []
+            y[loc] = []
+            xexp[loc] = float(t["X_FP_EXP"][t["LOCATION"]==loc][0])
+            yexp[loc] = float(t["Y_FP_EXP"][t["LOCATION"]==loc][0])
+            
+        x[loc].append(float(t["X_FP"][i]))
+        y[loc].append(float(t["Y_FP"][i]))
+
+theta=np.linspace(0,2*np.pi,50)
+
+locs=[]
+x1=[]
+y1=[]
+x2=[]
+y2=[]
+for count,loc in enumerate(x.keys()) :
+    if len(x[loc])<6 : continue
+    x[loc]=np.array(x[loc])
+    y[loc]=np.array(y[loc])
+    # here is the fit
+    xc,yc,r = fit_circle(x[loc],y[loc])
+    if r<0.1 : continue
+    print(loc,r)
+
+    if args.plot and count < 40 :
+        plt.figure("circles")
+        plt.plot(x[loc],y[loc],"o")
+        plt.plot(xexp[loc],yexp[loc],"x")
+        theta=np.linspace(0,2*np.pi,50)
+        plt.plot(xc+r*np.cos(theta),yc+r*np.sin(theta),"-",color="green")
+        plt.plot(xc,yc,"+",color="green")
+        
+    
+    x1.append(xexp[loc])
+    y1.append(yexp[loc])
+    x2.append(xc)
+    y2.append(yc)
+    locs.append(loc)
+    
+    if count>40 and args.plot : break
+
+locs=np.array(locs)
+x1=np.array(x1)
+y1=np.array(y1)
+x2=np.array(x2)
+y2=np.array(y2)
+dx=x2-x1
+dy=y2-y1
+dr=np.sqrt(dx**2+dy**2)
+print("median offset=",np.median(dr))
+ii=np.where(dr<0.2)[0]
+
+# make a table out of that
+t2=Table([locs[ii],x1[ii],y1[ii],x2[ii],y2[ii]],names=["LOCATION","X_FP_METRO","Y_FP_METRO","X_FP_THETA_AXIS","Y_FP_THETA_AXIS"],dtype=[int,float,float,float,float])
+
+t2.write(args.outfile,format="csv",overwrite=True)
+print("wrote",args.outfile)         
+
+plt.figure()
+plt.quiver(x1[ii],y1[ii],dx[ii],dy[ii])
+plt.show()
+
+    
+

--- a/bin/desi_fvc_proc
+++ b/bin/desi_fvc_proc
@@ -17,6 +17,7 @@ from desimeter.transform.fvc2fp.zb import FVCFP_ZhaoBurge
 from desimeter.match import match_same_system
 from desimeter.transform.xy2qs import qs2xy
 from desimeter.fieldmodel import FieldModel
+from desimeter.io import load_metrology
 
 parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                      description="""FVC image processing""")
@@ -40,8 +41,6 @@ parser.add_argument('--field-model', type = str, default = None, required = Fals
                     help = 'use this json file as field model to convert fiber coordinates to RA Dec')
 parser.add_argument('--fvc-psf-sigma', type = float, default = 1., required = False,
                     help = 'use this PSF sigma for the centroid measurement')
-
-
 
 args  = parser.parse_args()
 log   = get_logger()
@@ -97,12 +96,7 @@ if args.expected_positions is not None :
             log.error("No EXP_Q_0 nor X_FP in expected positions file {}".format(args.expected_positions))
 else :
     log.info("since no input expected positions, use metrology to match the fibers to the positioner centers")
-    filename = resource_filename('desimeter',"data/fp-metrology.csv")
-    if not os.path.isfile(filename) :
-        log.error("cannot find {}".format(filename))
-        raise IOError("cannot find {}".format(filename))
-    log.info("reading metrology in {}".format(filename)) 
-    expected_pos = Table.read(filename,format="csv")
+    expected_pos = load_metrology()
     
 if not "LOCATION" in expected_pos.keys() :
     # add useful location keyword
@@ -134,6 +128,7 @@ selection = (spots["X_FP_METRO"]!=0)
 spots["X_FP_EXP"][selection]=spots["X_FP_METRO"][selection]
 selection = (spots["Y_FP_METRO"]!=0)
 spots["Y_FP_EXP"][selection]=spots["Y_FP_METRO"][selection]
+
 
 # write transfo
 if args.output_transform is not None :

--- a/bin/desi_fvc_proc
+++ b/bin/desi_fvc_proc
@@ -27,6 +27,8 @@ parser.add_argument('-o','--outfile', type = str, default = None, required = Tru
                     help = 'path to output CSV ASCII file')
 parser.add_argument('--extname', type = str, default = 'F0000', required = False,
                     help = 'input EXTNAME to use if more than one HDU; last for last HDU')
+parser.add_argument('--sequence', action = 'store_true',
+                    help = 'loop over FXXXX extensions, will write one output file per extension replacing .csv by -XXXX.csv')
 parser.add_argument('--output-transform', type = str, default = None, required = False,
                     help = 'write transformation to this json file')
 parser.add_argument('--input-transform', type = str, default = None, required = False,
@@ -45,114 +47,138 @@ parser.add_argument('--fvc-psf-sigma', type = float, default = 1., required = Fa
 args  = parser.parse_args()
 log   = get_logger()
 
+if not args.outfile.endswith(".csv") :
+    print("sorry output filename has to end with .csv")
+    sys.exit(12)
+    
+spots_list=[]
+
 filename = args.infile
 if filename.find(".fits")>0 :
     log.info("read FITS FVC image")
     with fitsio.FITS(args.infile) as fx:
-        if len(fx) == 1:
-            image = fx[0].read().astype(float)
+        print(fx) # shockingly needed to get the attribute hdu_map
+        extnames = []
+        if args.sequence :
+            for extname in fx.hdu_map.keys() :
+                if isinstance(extname, str) and extname.lower().find("f0")==0 :
+                    extnames.append(extname)
+        elif len(fx) == 1:
+            extnames.append(0)
         elif args.extname.strip() != 'last':
-            image = fx[args.extname].read().astype(float)
-        else:
-            extnames = [k for k in fx.hdu_map.keys() if isinstance(k, str)]
-            extnames = [e.lower() for e in extnames]
+            extnames.append(args.extname)
+        else :
+            tmp_extnames = [k for k in fx.hdu_map.keys() if isinstance(k, str)]
+            tmp_extnames = [e.lower() for e in tmp_extnames]
             extname = None
-            for i in range(len(extnames)):
+            for i in range(len(tmp_extnames)):
                 extname0 = f'f{i:04d}'
-                if extname0 in extnames:
+                if extname0 in tmp_extnames:
                     extname = extname0
+            extnames.append(extname)
+
+        for extname in extnames :
+            log.info('reading image in extension {}'.format(extname))
             image = fx[extname].read().astype(float)
-            log.info(f'using extension {extname}...')
-    spots = detectspots(image,threshold=args.threshold,nsig=7,psf_sigma=args.fvc_psf_sigma)
+            spots_list.append( detectspots(image,threshold=args.threshold,nsig=7,psf_sigma=args.fvc_psf_sigma) )
+            
+        
 elif filename.find(".csv")>0 :
     log.info("read CSV spots table")
-    spots = Table.read(filename,format="csv")
+    spots_list.append( Table.read(filename,format="csv") )
 else :
     log.info("sorry, I don't know what to do with input file {} because not .fits nor .csv".format(filename))
     sys.exit(12)
 
-
-spots = findfiducials(spots,input_transform=args.input_transform)
-n_matched_pinholes = np.sum(spots['PINHOLE_ID'] > 0)
-n_matched_fiducials = np.sum(spots['PINHOLE_ID'] == 4)
-if n_matched_fiducials < 3:
-    log.error('Fewer than three matched fiducials; exiting early.')
-    sys.exit(13)
-
-
-tx = FVCFP_ZhaoBurge()
-tx.fit(spots, update_spots=True)
-
-if args.expected_positions is not None :
-    log.info("reading expected positions in {}".format(args.expected_positions))
-    expected_pos = Table.read(args.expected_positions) # auto-magically guess format
-    if not "X_FP_EXP" in expected_pos.keys() :
-        if "EXP_Q_0" in  expected_pos.keys() :
-            log.info("EXP_Q_0,EXP_S_0 -> X_FP,Y_FP")
-            x,y = qs2xy(q=expected_pos["EXP_Q_0"],s=expected_pos["EXP_S_0"])
-            expected_pos["X_FP"] = x
-            expected_pos["Y_FP"] = y
-        else :
-            log.error("No EXP_Q_0 nor X_FP in expected positions file {}".format(args.expected_positions))
-else :
-    log.info("since no input expected positions, use metrology to match the fibers to the positioner centers")
-    expected_pos = load_metrology()
-    
-if not "LOCATION" in expected_pos.keys() :
-    # add useful location keyword
-    expected_pos["LOCATION"] = np.array(expected_pos["PETAL_LOC"])*1000+np.array(expected_pos["DEVICE_LOC"])
-
-if "PINHOLE_ID" in expected_pos.dtype.names :
-    # exclude pinhole because here we want to match fibers
-    ii = np.where(expected_pos["PINHOLE_ID"]==0)[0]
-    expected_pos = expected_pos[:][ii]
-
-# select spots that are not already matched
-selection  = (spots["LOCATION"]==0)
-# match
-indices_of_expected_pos,distances = match_same_system(spots["X_FP"][selection],spots["Y_FP"][selection],expected_pos["X_FP"],expected_pos["Y_FP"])
-for maxdist in [0.1,1,5.] :
-    log.info("Number of match < {}mm = {}/{}".format(maxdist,np.sum(distances<maxdist),len(expected_pos)))
-
-# add columns after matching fibers
-for k1,k2 in zip(["X_FP","Y_FP"],["X_FP_EXP","Y_FP_EXP"]) :
-    if k2 not in spots.keys() : spots[k2] = np.zeros(len(spots))
-    spots[k2][selection]=expected_pos[k1][indices_of_expected_pos]
-for k in ["EXP_Q_0","EXP_S_0","PETAL_LOC","DEVICE_LOC","LOCATION"] :
-    if k in expected_pos.keys() :
-        if k not in spots.keys() : spots[k] = np.zeros(len(spots))
-        spots[k][selection]=expected_pos[k][indices_of_expected_pos]
-
-# for spots with metrology X_FP_EXP=X_FP_METRO
-selection = (spots["X_FP_METRO"]!=0)
-spots["X_FP_EXP"][selection]=spots["X_FP_METRO"][selection]
-selection = (spots["Y_FP_METRO"]!=0)
-spots["Y_FP_EXP"][selection]=spots["Y_FP_METRO"][selection]
+for seqid,spots in enumerate(spots_list) :
+    spots = findfiducials(spots,input_transform=args.input_transform)
+    n_matched_pinholes = np.sum(spots['PINHOLE_ID'] > 0)
+    n_matched_fiducials = np.sum(spots['PINHOLE_ID'] == 4)
+    if n_matched_fiducials < 3:
+        log.error('Fewer than three matched fiducials; exiting early.')
+        sys.exit(13)
 
 
-# write transfo
-if args.output_transform is not None :
-    if not args.output_transform.endswith(".json") :
-        print("error, can only write json files, so please choose an output filename end ing with .json")
+    tx = FVCFP_ZhaoBurge()
+    tx.fit(spots, update_spots=True)
+
+    if args.expected_positions is not None :
+        log.info("reading expected positions in {}".format(args.expected_positions))
+        expected_pos = Table.read(args.expected_positions) # auto-magically guess format
+        if not "X_FP_EXP" in expected_pos.keys() :
+            if "EXP_Q_0" in  expected_pos.keys() :
+                log.info("EXP_Q_0,EXP_S_0 -> X_FP,Y_FP")
+                x,y = qs2xy(q=expected_pos["EXP_Q_0"],s=expected_pos["EXP_S_0"])
+                expected_pos["X_FP"] = x
+                expected_pos["Y_FP"] = y
+            else :
+                log.error("No EXP_Q_0 nor X_FP in expected positions file {}".format(args.expected_positions))
     else :
-        tx.write_jsonfile(args.output_transform)
-        print("wrote transform in {}".format(args.output_transform))
+        log.info("since no input expected positions, use metrology to match the fibers to the positioner centers")
+        expected_pos = load_metrology()
+
+    if not "LOCATION" in expected_pos.keys() :
+        # add useful location keyword
+        expected_pos["LOCATION"] = np.array(expected_pos["PETAL_LOC"])*1000+np.array(expected_pos["DEVICE_LOC"])
+
+    if "PINHOLE_ID" in expected_pos.dtype.names :
+        # exclude pinhole because here we want to match fibers
+        ii = np.where(expected_pos["PINHOLE_ID"]==0)[0]
+        expected_pos = expected_pos[:][ii]
+
+    # select spots that are not already matched
+    selection  = (spots["LOCATION"]==0)
+    # match
+    indices_of_expected_pos,distances = match_same_system(spots["X_FP"][selection],spots["Y_FP"][selection],expected_pos["X_FP"],expected_pos["Y_FP"])
+    for maxdist in [0.1,1,5.] :
+        log.info("Number of match < {}mm = {}/{}".format(maxdist,np.sum(distances<maxdist),len(expected_pos)))
+
+    # add columns after matching fibers
+    for k1,k2 in zip(["X_FP","Y_FP"],["X_FP_EXP","Y_FP_EXP"]) :
+        if k2 not in spots.keys() : spots[k2] = np.zeros(len(spots))
+        spots[k2][selection]=expected_pos[k1][indices_of_expected_pos]
+    for k in ["EXP_Q_0","EXP_S_0","PETAL_LOC","DEVICE_LOC","LOCATION"] :
+        if k in expected_pos.keys() :
+            if k not in spots.keys() : spots[k] = np.zeros(len(spots))
+            spots[k][selection]=expected_pos[k][indices_of_expected_pos]
+
+    # for spots with metrology X_FP_EXP=X_FP_METRO
+    selection = (spots["X_FP_METRO"]!=0)
+    spots["X_FP_EXP"][selection]=spots["X_FP_METRO"][selection]
+    selection = (spots["Y_FP_METRO"]!=0)
+    spots["Y_FP_EXP"][selection]=spots["Y_FP_METRO"][selection]
 
 
-if args.field_model is not None :
-    log.info("Reading field model in {}".format(args.field_model))
-    with open(args.field_model) as file :
-        fm = FieldModel.fromjson(file.read())
-    spots["RA"] = np.zeros(len(spots),dtype=float)
-    spots["DEC"] = np.zeros(len(spots),dtype=float)
-    ii=(spots["X_FP"]!=0)&(spots["Y_FP"]!=0)
-    ra,dec = fm.fp2radec(spots["X_FP"][ii],spots["Y_FP"][ii])
-    spots["RA"][ii]  = ra
-    spots["DEC"][ii] = dec
+    # write transfo
+    if args.output_transform is not None :
+        if not args.output_transform.endswith(".json") :
+            print("error, can only write json files, so please choose an output filename end ing with .json")
+        else :
+            tx.write_jsonfile(args.output_transform)
+            print("wrote transform in {}".format(args.output_transform))
+
+
+    if args.field_model is not None :
+        log.info("Reading field model in {}".format(args.field_model))
+        with open(args.field_model) as file :
+            fm = FieldModel.fromjson(file.read())
+        spots["RA"] = np.zeros(len(spots),dtype=float)
+        spots["DEC"] = np.zeros(len(spots),dtype=float)
+        ii=(spots["X_FP"]!=0)&(spots["Y_FP"]!=0)
+        ra,dec = fm.fp2radec(spots["X_FP"][ii],spots["Y_FP"][ii])
+        spots["RA"][ii]  = ra
+        spots["DEC"][ii] = dec
 
     
-# write spots
-spots.write(args.outfile,format="csv",overwrite=True)
-print("wrote {}".format(args.outfile))
+        
+    if not args.sequence :
+        outfile=args.outfile
+    else :
+        outfile=args.outfile.replace(".csv","-F{:04d}.csv".format(seqid))
 
+    
+    # write spots
+    spots.write(outfile,format="csv",overwrite=True)
+    print("wrote {}".format(outfile))
+    
 

--- a/bin/plot_fvc_residuals
+++ b/bin/plot_fvc_residuals
@@ -99,13 +99,17 @@ elif jj.size > 0 : # sadly
 a.quiver(x,y,dx,dy)
 a.set_xlabel("X_FP (mm)")
 a.set_ylabel("Y_FP (mm)")
-a.legend(loc="upper left")
 
 dist=np.sqrt(dx**2+dy**2)
+
+rms=np.sqrt(np.mean(dist[dist<0.2]**2))
+blabla="rms(2D) = {:3.1f} um".format(rms*1000.)
+print(blabla)
+a.legend(loc="upper left",title=blabla)
+
 a2=fig.add_subplot(666)
 a2.hist(dist[dist<0.1]*1000.)
 a2.set_xlabel("dist. (um)")
-
 
 if False :
     print("Write coordinates of missing or incorrect fiducials")

--- a/bin/plot_positioner
+++ b/bin/plot_positioner
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+
+import argparse
+import os.path
+import sys
+import matplotlib.pyplot as plt
+import numpy as np
+from astropy.table import Table
+from pkg_resources import resource_filename
+
+def parse_fibers(fiber_string) :
+    """
+    Short func that parses a string containing a comma separated list of 
+    integers, which can include ":" or ".." or "-" labeled ranges
+
+    Args:
+        fiber_string (str) : list of integers or integer ranges
+
+    Returns (array 1-D):
+        1D numpy array listing all of the integers given in the list,
+        including enumerations of ranges given.
+
+    Note: this follows python-style ranges, i,e, 1:5 or 1..5 returns 1, 2, 3, 4
+    """
+    if fiber_string is None :
+        return np.array([])
+    else:
+        fiber_string = str(fiber_string)
+
+    if len(fiber_string.strip(' \t'))==0:
+        return np.array([])
+
+    fibers=[]
+
+
+    for sub in fiber_string.split(',') :
+        sub = sub.replace(' ','')
+        if sub.isdigit() :
+            fibers.append(int(sub))
+            continue
+
+        match = False
+        for symbol in [':','..','-']:
+            if not match and symbol in sub:
+                tmp = sub.split(symbol)
+                if (len(tmp) == 2) and tmp[0].isdigit() and tmp[1].isdigit() :
+                    match = True
+                    for f in range(int(tmp[0]),int(tmp[1])) :
+                        fibers.append(f)
+
+        if not match:
+            print("parsing error. Didn't understand {}".format(sub))
+            sys.exit(1)
+
+    return np.array(fibers)
+
+
+parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+                                     description="""Plot FVC spots, showing residuals with metrology""")
+parser.add_argument('-i','--infile', type = str, default = None, required = True, nargs="*",
+                    help = 'path to one or several FVC spots tables in CSV format (with X_FP,Y_FP,LOCATION columns)')
+parser.add_argument('--locations', type = str, default = None, required = True,
+                    help = 'list of locations to show (location=petal_loc*1000+device_loc, example 1012 , 1001,1002,1013 or 4040:4053 ...)')
+parser.add_argument('--legend', action = 'store_true',
+                    help = 'show legend')
+
+args  = parser.parse_args()
+
+fig = plt.figure(figsize=(6,6))
+
+locations=parse_fibers(args.locations)
+
+x=dict()
+y=dict()
+for l in locations :
+    x[l]=list()
+    y[l]=list()
+for filename in  args.infile :
+
+    table=Table.read(filename,format="csv")
+
+    for l in locations :
+        ii = np.where(table["LOCATION"]==l)[0]
+        x[l].append(table["X_FP"][ii])
+        y[l].append(table["Y_FP"][ii])
+for l in locations :
+    plt.plot(x[l],y[l],"o",label="LOC={:04d}".format(l))
+
+if args.legend :
+    plt.legend()
+plt.xlabel("XFP (mm)")
+plt.xlabel("YFP (mm)")
+plt.grid()
+plt.show()
+
+

--- a/bin/plot_positioner
+++ b/bin/plot_positioner
@@ -7,53 +7,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from astropy.table import Table
 from pkg_resources import resource_filename
-
-def parse_fibers(fiber_string) :
-    """
-    Short func that parses a string containing a comma separated list of 
-    integers, which can include ":" or ".." or "-" labeled ranges
-
-    Args:
-        fiber_string (str) : list of integers or integer ranges
-
-    Returns (array 1-D):
-        1D numpy array listing all of the integers given in the list,
-        including enumerations of ranges given.
-
-    Note: this follows python-style ranges, i,e, 1:5 or 1..5 returns 1, 2, 3, 4
-    """
-    if fiber_string is None :
-        return np.array([])
-    else:
-        fiber_string = str(fiber_string)
-
-    if len(fiber_string.strip(' \t'))==0:
-        return np.array([])
-
-    fibers=[]
-
-
-    for sub in fiber_string.split(',') :
-        sub = sub.replace(' ','')
-        if sub.isdigit() :
-            fibers.append(int(sub))
-            continue
-
-        match = False
-        for symbol in [':','..','-']:
-            if not match and symbol in sub:
-                tmp = sub.split(symbol)
-                if (len(tmp) == 2) and tmp[0].isdigit() and tmp[1].isdigit() :
-                    match = True
-                    for f in range(int(tmp[0]),int(tmp[1])) :
-                        fibers.append(f)
-
-        if not match:
-            print("parsing error. Didn't understand {}".format(sub))
-            sys.exit(1)
-
-    return np.array(fibers)
-
+from desimeter.util import parse_fibers
 
 parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                      description="""Plot FVC spots, showing residuals with metrology""")

--- a/py/desimeter/circles.py
+++ b/py/desimeter/circles.py
@@ -1,0 +1,109 @@
+"""
+Utility functions to fit circles from a set of cartesian coordinates
+"""
+
+import numpy as np
+from scipy import optimize
+
+#- Least squares fit to circle; adapted from "Method 2b" in
+#- https://scipy-cookbook.readthedocs.io/items/Least_Squares_Circle.html
+
+def fit_circle(x, y):
+    """
+    fit a circle from a set of 2D cartesian coordinates
+    Args:
+        x : float numpy array of coordinates along first axis of cartesian coordinate system
+        y : float numpy array of coordinates along second axis in same system
+
+    returns:
+        xc : float, coordinates along first axis of center of circle 
+        yc : float, coordinates along second axis of center of circle
+        r  : float, radius of circle
+    """
+    
+    x_m, y_m, r = _fast_fit_circle(x, y)
+    
+    #- If r is too small or too big then either this positioner wasn't moving
+    #- or the points are mismatched for a bad fit.
+    if (r < 1.0) or (r > 5.0):
+        raise ValueError('Bad circle fit')
+
+    def calc_R(xc, yc):
+        """ calculate the distance of each data points from the center (xc, yc) """
+        return np.sqrt((x-xc)**2 + (y-yc)**2)
+
+    def f_2b(c):
+        """ calculate the algebraic distance between the 2D points and the mean circle centered at c=(xc, yc) """
+        Ri = calc_R(*c)
+        return Ri - Ri.mean()
+
+    def Df_2b(c):
+        """ Jacobian of f_2b
+        The axis corresponding to derivatives must be coherent with the col_deriv option of leastsq"""
+        xc, yc     = c
+        df2b_dc    = np.empty((len(c), x.size))
+
+        Ri = calc_R(xc, yc)
+        df2b_dc[0] = (xc - x)/Ri                   # dR/dxc
+        df2b_dc[1] = (yc - y)/Ri                   # dR/dyc
+        df2b_dc    = df2b_dc - df2b_dc.mean(axis=1)[:, np.newaxis]
+
+        return df2b_dc
+
+    
+    center_estimate = x_m, y_m
+    center_2b, ier = optimize.leastsq(f_2b, center_estimate, Dfun=Df_2b, col_deriv=True)
+
+    xc_2b, yc_2b = center_2b
+    Ri_2b        = calc_R(*center_2b)
+    R_2b         = Ri_2b.mean()
+    residu_2b    = sum((Ri_2b - R_2b)**2)
+
+    if (R_2b < 1.0) or (R_2b > 5.0):
+        raise ValueError('Bad circle fit')
+
+    return xc_2b, yc_2b, R_2b
+
+def _fast_fit_circle(x,y) :
+    """
+    fast and approximate method to fit a circle from a set of 2D cartesian coordinates
+    (better use fit_circle)
+    Args:
+        xin : float numpy array of coordinates along first axis of cartesian coordinate system
+        yin : float numpy array of coordinates along second axis in same system
+
+    returns:
+        xc : float, coordinates along first axis of center of circle 
+        yc : float, coordinates along second axis of center of circle
+        r  : float, radius of circle
+    """
+    # init
+    nn=len(x)
+    i1=np.arange(nn)
+    ### i2=(i1+1)%nn
+    i2=(i1+nn//2-1)%nn
+    
+    # midpoints
+    mx=((x[i1]+x[i2])/2.)
+    my=((y[i1]+y[i2])/2.)
+    nx=(y[i2]-y[i1])
+    ny=-(x[i2]-x[i1])
+
+    # solve for intersection of perpendicular bisectors
+    # with s1,s2 are affine parameters of 2 adjacent perpendicular bisectors
+    # 2 equations:
+    # mx1 + nx1*s1 = mx2 + nx2*s2
+    # my1 + ny1*s1 = my2 + ny2*s2
+    s1 = (ny[i2]*mx[i2]-nx[i2]*my[i2]-ny[i2]*mx[i1]+nx[i2]*my[i1])/(ny[i2]*nx[i1]-nx[i2]*ny[i1])
+
+    # coordinates of intersections are estimates of center of circle
+    xc=mx[i1]+nx[i1]*s1[i1]
+    yc=my[i1]+ny[i1]*s1[i1]
+    
+    # first estimate of center is mean of all intersections
+    xc=np.mean(xc)
+    yc=np.mean(yc)
+    r=np.mean(np.sqrt((x-xc)**2+(y-yc)**2))
+   
+    return xc,yc,r
+

--- a/py/desimeter/detectspots.py
+++ b/py/desimeter/detectspots.py
@@ -199,7 +199,7 @@ def detectspots(fvcimage,threshold=500,nsig=7,psf_sigma=1.) :
     if xoffset !=0 or yoffset !=0 :
         log.warning("Applying offsets x += {} and y += {} (to match with others, like the POS files)".format(xoffset,yoffset))
     if xoffset == 0 and yoffset == 0 :
-        log.warning("Here center of first pixel has coord=(0,0); so we expect offsets of 1 with respect to coordinates in .pos files.")
+        log.debug("Here center of first pixel has coord=(0,0); so we expect offsets of 1 with respect to coordinates in .pos files.")
     
     for j,index in enumerate(peakindices) :
         i0=index//n1

--- a/py/desimeter/test/test_corr.py
+++ b/py/desimeter/test/test_corr.py
@@ -8,16 +8,22 @@ from desimeter.simplecorr import SimpleCorr
 class TestCorr(unittest.TestCase):
     
      def test_simple_corr(self):
-        print("Testing match with arbitrary translation and dilatation")
+        print("Testing simple corr")
         nn=12
         x1=np.random.uniform(size=nn)-0.5
         y1=np.random.uniform(size=nn)-0.5
         
+        # arb. angle
+        a=10./180.*np.pi
+        ca=np.cos(a)
+        sa=np.sin(a)
+
         # arb. dilatation
         xscale = 12.
         yscale = 13.
-        x3 = xscale*x1
-        y3 = yscale*y1
+        x3 =  xscale*ca*x1 + yscale*sa*y1
+        y3 = -xscale*sa*x1 + yscale*ca*y1
+        
         # arb. translation
         x3 += 33.
         y3 += 11.
@@ -34,6 +40,33 @@ class TestCorr(unittest.TestCase):
 
         dist=np.sqrt((x1b-x3)**2+(y1b-y3)**2)
         assert(np.all(dist<1e-6))
+
+     def test_fit_rotoff(self):
+        print("Testing fit_rotoff")
+        nn=12
+        x1=np.random.uniform(size=nn)-0.5
+        y1=np.random.uniform(size=nn)-0.5
+
+        # arb. angle
+        a=22./180.*np.pi
+        ca=np.cos(a)
+        sa=np.sin(a)
+        
+        # arb. translation
+        x3 = 33.  + ca*x1 + sa*y1
+        y3 = 11. - sa*x1 + ca*y1
+        
+        corr31=SimpleCorr()
+        corr31.fit_rotoff(x3,y3,x1,y1)
+        x3b,y3b=corr31.apply(x3,y3)
+        dist=np.sqrt((x3b-x1)**2+(y3b-y1)**2)
+        assert(np.all(dist<1e-8))
+
+        corr13=SimpleCorr()
+        corr13.fit_rotoff(x1,y1,x3,y3)
+        x1b,y1b=corr13.apply(x1,y1)
+        dist=np.sqrt((x3-x1b)**2+(y3-y1b)**2)
+        assert(np.all(dist<1e-8))
 
         
 if __name__ == '__main__':

--- a/py/desimeter/transform/xy2qs.py
+++ b/py/desimeter/transform/xy2qs.py
@@ -48,3 +48,18 @@ def qs2xy(q, s):
     y = r*np.sin(np.radians(q))
 
     return x, y
+
+#- Transform between CS5 x,y and curved focal surface
+def xy2uv(x, y):
+    q, s = xy2qs(x, y)
+    qrad = np.radians(q)
+    u = s*np.cos(qrad)
+    v = s*np.sin(qrad)
+    return u, v
+
+def uv2xy(u, v):
+    s = np.sqrt(u**2 + v**2)
+    qrad = np.arctan2(v, u)
+    q = np.degrees(qrad)
+    x, y = qs2xy(q, s)
+    return x, y

--- a/py/desimeter/util.py
+++ b/py/desimeter/util.py
@@ -1,0 +1,51 @@
+"""
+Utility functions
+"""
+
+import numpy as np
+
+def parse_fibers(fiber_string) :
+    """
+    Short func that parses a string containing a comma separated list of 
+    integers, which can include ":" or ".." or "-" labeled ranges
+
+    Args:
+        fiber_string (str) : list of integers or integer ranges
+
+    Returns (array 1-D):
+        1D numpy array listing all of the integers given in the list,
+        including enumerations of ranges given.
+
+    Note: this follows python-style ranges, i,e, 1:5 or 1..5 returns 1, 2, 3, 4
+    """
+    if fiber_string is None :
+        return np.array([])
+    else:
+        fiber_string = str(fiber_string)
+
+    if len(fiber_string.strip(' \t'))==0:
+        return np.array([])
+
+    fibers=[]
+
+
+    for sub in fiber_string.split(',') :
+        sub = sub.replace(' ','')
+        if sub.isdigit() :
+            fibers.append(int(sub))
+            continue
+
+        match = False
+        for symbol in [':','..','-']:
+            if not match and symbol in sub:
+                tmp = sub.split(symbol)
+                if (len(tmp) == 2) and tmp[0].isdigit() and tmp[1].isdigit() :
+                    match = True
+                    for f in range(int(tmp[0]),int(tmp[1])) :
+                        fibers.append(f)
+
+        if not match:
+            print("parsing error. Didn't understand {}".format(sub))
+            sys.exit(1)
+
+    return np.array(fibers)


### PR DESCRIPTION
Add 
 - code option to extract coordinates of spots for a positioner calibration or grid calibration.
 - code to fit circles and directly match to metrology.

Example
```
desi_fvc_proc -i /global/cfs/cdirs/desi/spectro/data/20200228/00052644/fvc-00052644.fits.fz --sequence -o fvc-00052644.csv
desi_fit_circles -i fvc-00052644-F000{0,1,2,3,4,5,6}.csv -o circles.csv --plot
```
![circles](https://user-images.githubusercontent.com/5192160/78410310-bccddc80-75c0-11ea-906c-9bc9d411da11.png)
![quiver](https://user-images.githubusercontent.com/5192160/78410313-bf303680-75c0-11ea-8867-18e6030a34ee.png)

