### PR TITLE
allow posparam fitting less than one day of data

### DIFF
--- a/bin/get_posmov_fvc_data
+++ b/bin/get_posmov_fvc_data
@@ -181,6 +181,11 @@ for petalid in petalids :
             
         
         jj = np.where(np.in1d(tstamp_posmovedb,posid_tstamp_posmovedb[posid]))[0]
+
+        if jj.size == 0:
+            print("ERROR: {} {}/{} DB entries match desimeter data".format(posid,jj.size, len(data)))
+            continue
+
         print("for {} got {} entries in db, with {} matched to desimeter data".format(posid,len(data),jj.size))
         kk = np.argsort(tstamp_posmovedb[jj])
         jj = jj[kk]

--- a/py/desimeter/posparams/fithandler.py
+++ b/py/desimeter/posparams/fithandler.py
@@ -29,17 +29,18 @@ output_keys = {'POS_ID': False,
 output_keys.update({key:True for key in fitter.all_keys})
 
 def run_best_fits(posid, path, period_days, data_window, savedir,
-                  static_quantile, printf=print):
+                  static_quantile, printf=print, min_window=10):
     '''Define best-fit analysis cases for one positioner.
 
     INPUTS:
         posid ... positioner id string
         path ... file path to csv containing measured (x,y) vs internal (t,p) data
         period_days ... minimum number of days per best-fit
-        data_window ... mininum number of data points per best-fit
+        data_window ... number of data points per best-fit
         savedir ... directory to save result files
         static_quantile ... least-error group of static params to median --> overall best
         printf ... print function (so you can control how this module spits any messages)
+        min_window ... (optional) minimum number of data points to attempt a fit
 
     OUTPUTS:
         logstr ... string describing (very briefly) what was done. suitable for
@@ -50,8 +51,8 @@ def run_best_fits(posid, path, period_days, data_window, savedir,
         return f'{posid}: dropped from analysis (invalid table)'
     _make_petal_xy(table, printf=printf)
     _apply_filters(table, printf=printf)
-    if not table or len(table) < 10:
-        return f'{posid}: dropped from analysis (insufficient data remaining after filters applied)'
+    if not table or len(table) < min_window:
+        return f'ERROR: {posid} dropped from analysis because {len(table)}<{min_window} is insufficient data remaining after filters applied'
     _make_sec_from_epoch(table, printf=printf)
     period_sec = period_days * 24 * 60 * 60
     datum_dates = np.arange(min(table['DATE_SEC']), max(table['DATE_SEC']), period_sec)


### PR DESCRIPTION
Allow `fit_posparams` to work on a single day of data.  Previously this `fithandler.py` code wouldn't process any data if `len(datum_dates)==1`:

```python
    for j in range(1, len(datum_dates)):
        start_date = datum_dates[j - 1]
        ...
```
The solution here is to catch that as a special case ahead of time, leaving the existing `_define_cases` behavior unchanged for the original use case of grouping many moves over many nights.