### PR TITLE
support astropy 3.0.4 and matplotlib 2.1.2

### DIFF
--- a/bin/plot_posparams
+++ b/bin/plot_posparams
@@ -71,7 +71,7 @@ for path in infiles:
         this_table = Table.read(path, format='csv')
         tables += [this_table]
 table = vstack(tables)
-table.sort('POS_ID', 'DATA_END_DATE_SEC')
+table.sort(['POS_ID', 'DATA_END_DATE_SEC'])
 analysis_timestamp = Time(min(table['ANALYSIS_DATE_STATIC'])).iso.split('.')[0]
 analysis_timestamp_for_filename = Time(analysis_timestamp).isot.replace('-','').replace(':','')[:-4]
 

--- a/py/desimeter/posparams/plotter.py
+++ b/py/desimeter/posparams/plotter.py
@@ -122,7 +122,7 @@ def plot_passfail(binned, savepath, title='', printf=print):
         plt.ylabel(p['ylabel'], fontsize=14)
         plt.legend(title='THRESHOLDS (mm)')
         path = split[0] + p['suffix'] + split[1]
-        plt.title(title, fontfamily='monospace')
+        plt.title(title, family='monospace')
         plt.grid(color='0.9')
         plt.minorticks_on()
         plt.gca().tick_params(axis='x', which='minor', bottom=False)


### PR DESCRIPTION
This PR has two small changes that I needed for plot_posparams to work with astropy 3.0.4 and matplotlib 2.1.2.

@joesilber please test this with whatever versions you used to develop plot_posparams to check if these changes work for your versions as well.

Notes:
* astropy table sorting with multiple keys: I think this was a bug in desimeter that was either introduced after plot_posparams was last tested, or it accidentally worked with some version of astropy.  I'm pretty sure that the correct multi-key syntax for sorting table is providing a list of key names as a single argument, not the key names as separate arguments.
* matplotlib "fontfamily" vs. "family": the matplotlib 2.1.2 documentation clearly says that "fontfamily" should work, but experimentally I find that only "family" works with matplotlib 2.1.2, which appears to be a bug that was likely fixed in a later version that you are using.