### PR TITLE
Outlier rejection in fit_posparams

### DIFF
--- a/py/desimeter/posparams/fitter.py
+++ b/py/desimeter/posparams/fitter.py
@@ -264,7 +264,7 @@ def fit_params(posintT, posintP, ptlX, ptlY, gearT, gearP,
     initial_params = [nominals[key] for key in params_to_fit]
     bounds_vector = [bounds[key] for key in params_to_fit]
     # with fun = chi2 , then covariance = inverse of hessian * 2
-    for iteration in range(20) :
+    for _ in range(20) :
         optimizer_result = scipy.optimize.minimize(fun=compute_chi2,
                                                    x0=initial_params,
                                                    bounds=bounds_vector)


### PR DESCRIPTION
Implemented outlier rejection in `fit_posparams` .
Recovered M06998,M01985,M08052 with this change.
Example, M08052 (calib. arcs only):
![M08052-calib-only](https://user-images.githubusercontent.com/5192160/84299122-11339200-ab05-11ea-8a53-bebc7fd887a6.png)

calib. arcs + extra points:
![M08052-calib-and-extra](https://user-images.githubusercontent.com/5192160/84299217-3b854f80-ab05-11ea-9342-7b2f62772e1a.png)

The fit has been performed with the extra points so many points were discarded in this fit.
