### PR TITLE
Posmoves recent rehome

### DIFF
--- a/bin/fit_posparams
+++ b/bin/fit_posparams
@@ -43,7 +43,7 @@ parser.add_argument('-o', '--outdir', type=str, required=True,
                     help='path to directory where to save output files')
 parser.add_argument('-dw', '--data_window', type=int, default=100,
                     help='minimum width (num pts) for window swept through historical data')
-parser.add_argument('-pd', '--period_days', type=int, default=1,
+parser.add_argument('-pd', '--period_days', type=int, default=10000,
                     help='spacing of datum dates at which to run the fit')
 parser.add_argument('-np', '--n_processes_max', type=int, default=None,
                     help='max number of processors to use. Note: can argue 1 to avoid multiprocessing pool (useful for debugging)')

--- a/bin/fit_posparams
+++ b/bin/fit_posparams
@@ -41,9 +41,9 @@ parser.add_argument('-i', '--infiles', type=str, required=True, nargs='*',
                          'Multiple file args also ok (like M0001.csv M0002.csv M01*.csv)')
 parser.add_argument('-o', '--outdir', type=str, required=True,
                     help='path to directory where to save output files')
-parser.add_argument('-dw', '--data_window', type=int, default=100,
+parser.add_argument('-dw', '--data_window', type=int, default=1000000,
                     help='minimum width (num pts) for window swept through historical data')
-parser.add_argument('-pd', '--period_days', type=int, default=10000,
+parser.add_argument('-pd', '--period_days', type=int, default=1000000,
                     help='spacing of datum dates at which to run the fit')
 parser.add_argument('-np', '--n_processes_max', type=int, default=None,
                     help='max number of processors to use. Note: can argue 1 to avoid multiprocessing pool (useful for debugging)')

--- a/bin/get_posmoves
+++ b/bin/get_posmoves
@@ -25,6 +25,7 @@ parser.add_argument('--date-max', type = str, default = "2030-01-01", required =
 parser.add_argument('--pos-ids', type= str, required=False, default=None, help="comma separated list of positioner ids (same as DEVICE_ID)")
 parser.add_argument('-o','--outdir', type = str, default = "None", required = True, help="output directory where MXXXX.csv files are saved")
 parser.add_argument('--with-calib', action = 'store_true', help="add matching calib from db")
+parser.add_argument('--recent-rehome-exposure-ids', type= str, required=False, default=None, help="comma separated list of exposure ids where the positioners have been recently rehomed")
 
 args  = parser.parse_args()
 
@@ -38,6 +39,10 @@ if args.petal_ids is not None :
     petalids = parse_fibers(args.petal_ids)
 else :
     petalids = get_petal_ids(comm)
+
+recent_rehome_exposure_ids=list()
+if args.recent_rehome_exposure_ids is not None :
+    recent_rehome_exposure_ids=[int(val) for val in args.recent_rehome_exposure_ids.split(",")]
 
 for petalid in petalids :
 
@@ -115,6 +120,8 @@ for petalid in petalids :
                 k2=k.upper()
 
             otable[k2]=np.array(posmoves[k])
+
+        otable["RECENT_REHOME"]=np.in1d(otable["EXPOSURE_ID"],recent_rehome_exposure_ids)
 
         if not os.path.isdir(args.outdir) :
             os.makedirs(args.outdir)

--- a/bin/get_posmoves
+++ b/bin/get_posmoves
@@ -121,7 +121,7 @@ for petalid in petalids :
 
             otable[k2]=np.array(posmoves[k])
 
-        otable["RECENT_REHOME"]=np.in1d(otable["EXPOSURE_ID"],recent_rehome_exposure_ids)
+        otable["RECENT_REHOME"]=np.in1d(otable["EXPOSURE_ID"],recent_rehome_exposure_ids).astype(int)
 
         if not os.path.isdir(args.outdir) :
             os.makedirs(args.outdir)

--- a/py/desimeter/circles.py
+++ b/py/desimeter/circles.py
@@ -94,7 +94,11 @@ def _fast_fit_circle(x,y,use_median=False) :
     # 2 equations:
     # mx1 + nx1*s1 = mx2 + nx2*s2
     # my1 + ny1*s1 = my2 + ny2*s2
-    s1 = (ny[i2]*mx[i2]-nx[i2]*my[i2]-ny[i2]*mx[i1]+nx[i2]*my[i1])/(ny[i2]*nx[i1]-nx[i2]*ny[i1])
+    num   = (ny[i2]*mx[i2]-nx[i2]*my[i2]-ny[i2]*mx[i1]+nx[i2]*my[i1])
+    denom = (ny[i2]*nx[i1]-nx[i2]*ny[i1])
+    ok = (denom!=0)
+    s1 = np.zeros(nn)
+    s1[ok] = num[ok]/denom[ok]
 
     # coordinates of intersections are estimates of center of circle
     xc=mx[i1]+nx[i1]*s1[i1]

--- a/py/desimeter/dbutil.py
+++ b/py/desimeter/dbutil.py
@@ -37,7 +37,7 @@ def get_petal_ids(comm) :
     return petalids
 
 def get_pos_ids(comm, petal_id) :
-    res=dbquery(comm,"select distinct pos_id from posmovedb.positioner_moves_p%d",(petal_id,))
+    res=dbquery(comm,"select distinct pos_id from posmovedb.positioner_moves_p%s",(int(petal_id),))
     return res["pos_id"]
 
 def get_petal_loc(petal_id) :

--- a/py/desimeter/posparams/fitter.py
+++ b/py/desimeter/posparams/fitter.py
@@ -60,7 +60,7 @@ static_keys = ['LENGTH_R1', 'LENGTH_R2', 'OFFSET_T', 'OFFSET_P', 'OFFSET_X', 'OF
 dynamic_keys = ['SCALE_T', 'SCALE_P']
 all_keys = static_keys + dynamic_keys
 
-def fit_params(posintT, posintP, ptlX, ptlY, gearT, gearP,
+def fit_params(posintT, posintP, ptlX, ptlY, gearT, gearP, recent_rehome, sequence_id,
                mode='static',
                nominals=None,
                bounds=None,
@@ -84,6 +84,10 @@ def fit_params(posintT, posintP, ptlX, ptlY, gearT, gearP,
 
         gearT    ... list of GEAR_CALIB_T at the time the robot made the move
         gearP    ... list of GEAR_CALIB_P at the time the robot made the move
+
+        recent_rehome ... bool, if true, positioner was recently rehomed, posintT,P are accurate
+                          and we can measured OFFSET_T,P instead of DELTA_T,P
+        sequence_id ... int, one set of DELTA_T,P per sequence
 
         mode     ... 'static' or 'dynamic'
                      In static mode, all "dynamic" parameters will be held fixed,
@@ -118,8 +122,8 @@ def fit_params(posintT, posintP, ptlX, ptlY, gearT, gearP,
     if keep_fixed is None:
         keep_fixed = []
     # arg checking
-    assert len(posintT) == len(posintP) == len(ptlX) == len(ptlY) == len(gearT) == len(gearP)
-    assert all(isinstance(arg, list) for arg in (posintT, posintP, ptlX, ptlY, gearT, gearP))
+    assert len(posintT) == len(posintP) == len(ptlX) == len(ptlY) == len(gearT) == len(gearP) == len(recent_rehome) == len(sequence_id)
+    assert all(isinstance(arg, list) for arg in (posintT, posintP, ptlX, ptlY, gearT, gearP, recent_rehome, sequence_id))
     assert all(math.isfinite(x) for x in posintT + posintP + ptlX + ptlY + gearT + gearP)
     assert mode in {'static', 'dynamic'}
     assert all(key in nominals for key in all_keys)
@@ -131,6 +135,9 @@ def fit_params(posintT, posintP, ptlX, ptlY, gearT, gearP,
     if ptlYerr is not None :
         assert len(ptlYerr) == len(ptlY)
         assert isinstance(ptlYerr,list)
+
+    print("WARNING, need to do something with sequence_id=",sequence_id)
+    print("WARNING, need to do something with recent_rehome=",recent_rehome)
 
     # evaluate and check move flags before fitting
     flags = eval_move_flags(posintT, posintP, ptlX, ptlY)

--- a/py/desimeter/posparams/fitter.py
+++ b/py/desimeter/posparams/fitter.py
@@ -138,18 +138,20 @@ def fit_params(posintT, posintP, ptlX, ptlY, gearT, gearP, recent_rehome, sequen
 
     sequence_id=np.array(sequence_id)
     recent_rehome=np.array(recent_rehome)
-    if not np.any(recent_rehome) :
-        print("ERROR: Need at least one measurement with recent_rehome to fit OFFSET_T,P")
+
+
+    # evaluate and check move flags before fitting
+    flags = eval_move_flags(posintT, posintP, ptlX, ptlY)
+    if (flags & (movemask['THETA_STUCK'] | movemask['PHI_STUCK']))  > 0 :
+        print("WARNING: positioner not moving in one axis")
         flags |= movemask['FAILED_FIT']
         best_params = {"FLAGS": flags}
         covariance_dict = dict()
         rms_of_residuals = 0.
         return best_params, covariance_dict, rms_of_residuals
 
-    # evaluate and check move flags before fitting
-    flags = eval_move_flags(posintT, posintP, ptlX, ptlY)
-    if (flags & (movemask['THETA_STUCK'] | movemask['PHI_STUCK']))  > 0 :
-        print("WARNING: positioner not moving in one axis")
+    if not np.any(recent_rehome) :
+        print("ERROR: Need at least one measurement with recent_rehome to fit OFFSET_T,P")
         flags |= movemask['FAILED_FIT']
         best_params = {"FLAGS": flags}
         covariance_dict = dict()

--- a/py/desimeter/posparams/flags.py
+++ b/py/desimeter/posparams/flags.py
@@ -33,18 +33,18 @@ def eval_move_flags(posintT, posintP, ptlX, ptlY) :
 
     tested = False
     moving = False
-    print("DEBUG: unique P values = {}".format(unique_p_int))
+    #print("DEBUG: unique P values = {}".format(unique_p_int))
     for val in unique_p_int :
         selection = np.where(p_int==val)[0]
         if len(selection)<4 :
-            print("DEBUG: for p={} , {} pts: too few points to detect anything".format(val,selection.size))
+            #print("DEBUG: for p={} , {} pts: too few points to detect anything".format(val,selection.size))
             continue # too few points to detect anything
         if val>160 :
-            print("DEBUG: p={} phi arm is too much retracted to measure variations in theta".format(val))
+            #print("DEBUG: p={} phi arm is too much retracted to measure variations in theta".format(val))
             continue # phi arm is too much retracted to measure variations in theta
         t_int_range = np.max(t_int[selection])-np.min(t_int[selection])
         if t_int_range<20. :
-            print("DEBUG: range of t={}: range of theta angle is to small".format(t_int_range))
+            #print("DEBUG: range of t={}: range of theta angle is to small".format(t_int_range))
             continue # range of theta angle is to small
 
         tested = True


### PR DESCRIPTION
* Add option `--recent-rehome` to declare in `get_posmoves` which calibration exposure(s) had a recent rehome. This sets to true the values in the column `RECENT_REHOME` for the moves of these exposures. Ex.
```
# use expid=2107 on 2020/06/05, but assume no recent-rehome
# good RC on 2020/06/08 for most positioners, expid=2119
get_posmoves --host xxx--port xxx --password xxx --exposure-ids 2107,2119 --petal-id 1 -o . --recent-rehome 2119
```
* Use this information in the fit: Add as many extra (nuisance) parameters `EPSILON_T,P_xxx` as there are sequences of "consistent POS_T,P" for which RECENT_REHOME=False. The ` EPSILON_T,P` absorb the drifts of `POS_T,P` such that the parameters `OFFSET_T,P` only encode the actual orientation of the positioners in the petal.

* The fitter is now complex and really needs to be reorganized, but it would be useful to commit and tag the current version that is working, because it includes what we want (covariances, outlier rejection, flags and detection of failures, fit of OFFSET_T,P only on rehomed data).

Full example
```
# use expid=2107 on 2020/06/05, but assume no recent-rehome
# good RC on 2020/06/08 for most positioners, expid=2119
get_posmoves --host beyonce.lbl.gov --port 5432 --password reader --exposure-ids 2107,2119 --petal-id 1 -o . --recent-rehome 2119
# new RC on 2020/06/09 for some positioners, expid=2141, overwrite them
get_posmoves --host beyonce.lbl.gov --port 5432 --password reader --exposure-ids 2141 --petal-id 1 -o . --recent-rehome 2141 --pos-ids M06248,M06223,M06226,M06252,M08138
# new RC on 2020/06/10 for some positioners, expid=2154, overwrite them
get_posmoves --host beyonce.lbl.gov --port 5432 --password reader --exposure-ids 2154 --petal-id 1 -o . --recent-rehome 2154 --pos-ids M08052,M06998,M01985

fit_posparams -i M?????.csv -o .
merge_posparams -i M*_paramfits.csv -o all_paramfits.csv
../../scripts/plot_paramfits.py all_paramfits.csv

GOOD (10 worst):
M06478 rms=0.050 x=69.6 y=23.3
M06520 rms=0.025 x=32.8 y=14.2
M02202 rms=0.024 x=59.1 y= 5.2
M02491 rms=0.023 x=48.6 y= 5.1
M01985 rms=0.021 x=205.4 y=131.8
M06523 rms=0.020 x=43.3 y=14.2
M06998 rms=0.020 x=194.9 y=113.8
M06257 rms=0.020 x=48.6 y=23.3
M08052 rms=0.020 x=148.1 y=14.3
M02182 rms=0.020 x=101.1 y= 5.2

BAD:
FLAGGED:
M01639 FLAGS=8 ['INVALID_TABLE']
M06190 FLAGS=5 ['THETA_STUCK', 'FAILED_FIT']
M06469 FLAGS=8 ['INVALID_TABLE']
M06805 FLAGS=16 ['INVALID_AFTER_FILTER']
M06807 FLAGS=8 ['INVALID_TABLE']
M06923 FLAGS=8 ['INVALID_TABLE']
M06925 FLAGS=16 ['INVALID_AFTER_FILTER']
M06926 FLAGS=16 ['INVALID_AFTER_FILTER']
M06928 FLAGS=16 ['INVALID_AFTER_FILTER']
M07112 FLAGS=5 ['THETA_STUCK', 'FAILED_FIT']
M07699 FLAGS=5 ['THETA_STUCK', 'FAILED_FIT']
M08203 FLAGS=16 ['INVALID_AFTER_FILTER']
M08272 FLAGS=16 ['INVALID_AFTER_FILTER']
M08273 FLAGS=16 ['INVALID_AFTER_FILTER']
M08348 FLAGS=5 ['THETA_STUCK', 'FAILED_FIT']
```
![Figure_3](https://user-images.githubusercontent.com/5192160/84683455-153c2700-aeec-11ea-9756-faf4597f4d19.png)
![Figure_2](https://user-images.githubusercontent.com/5192160/84683459-15d4bd80-aeec-11ea-9105-451130440c56.png)
![Figure_1](https://user-images.githubusercontent.com/5192160/84683461-15d4bd80-aeec-11ea-9dc5-8befb7b7cc22.png)
