### PR TITLE
Detect moving positioners

### DIFF
--- a/bin/average_coordinates
+++ b/bin/average_coordinates
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+import argparse
+from astropy.table import Table
+from desimeter.averagecoord import average_coordinates
+
+parser = argparse.ArgumentParser(description="average coordinates in tables.")
+parser.add_argument('-i', '--infiles', type=str, required=True, nargs="*",
+                    help='path to several input csv table file(s)')
+parser.add_argument('--xkey', type=str, required=False, default="XPIX")
+parser.add_argument('--ykey', type=str, required=False, default="YPIX")
+parser.add_argument('-o', '--outfile', type=str, required=True,
+                    help='output csv file with averaged coordinates')
+
+args = parser.parse_args()
+tables = list()
+for filename in args.infiles :
+    tables.append(Table.read(filename))
+table = average_coordinates(tables,args.xkey,args.ykey)
+table.write(args.outfile,overwrite=True)
+print("wrote",args.outfile)
+
+

--- a/bin/compute_distance_from_center
+++ b/bin/compute_distance_from_center
@@ -33,6 +33,8 @@ if args.pos_ids is not None :
 elif args.other_table_with_device_ids is not None :
     tmp=Table.read(args.other_table_with_device_ids)
     posids = list(tmp["DEVICE_ID"])
+else :
+    posids = None
 
 m=load_metrology()
 

--- a/bin/compute_distance_from_center
+++ b/bin/compute_distance_from_center
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+
+import sys
+import numpy as np
+import matplotlib.pyplot as plt
+from desimeter.io import load_metrology
+from astropy.table import Table
+from desimeter.match import match_same_system
+from desimeter.simplecorr import SimpleCorr
+from desimeter.io import load_metrology,fvc2fp_filename
+from desimeter.transform.fvc2fp import FVC2FP
+from desimeter.transform.ptl2fp import fp2ptl
+from desimeter.transform.xy2qs import xy2qs
+from desimeter.processfvc import process_fvc
+
+from scipy.spatial import cKDTree as KDTree
+import argparse
+
+parser = argparse.ArgumentParser(description="match positioners by first detecting the moving ones.")
+parser.add_argument('-i', '--infile', type=str, required=True, default=None,
+                    help='path to input fits or csv FVC file')
+parser.add_argument('-p', '--pos-ids', type=str, required=False, default=None,
+                    help='comma separated list of positioners')
+parser.add_argument('--other-table-with-device-ids', type=str, required=False, default=None,
+                    help='show results for positioners given by DEVICE_ID column in this filename')
+
+args=parser.parse_args()
+
+t=process_fvc(args.infile)
+
+if args.pos_ids is not None :
+    posids = args.pos_ids.split(",")
+elif args.other_table_with_device_ids is not None :
+    tmp=Table.read(args.other_table_with_device_ids)
+    posids = list(tmp["DEVICE_ID"])
+
+m=load_metrology()
+
+if posids is not None :
+    dist = {p:-1 for p in posids}
+else :
+    dist = dict()
+
+for i,loc in enumerate(t["LOCATION"]):
+    if loc<0 : continue # not a match
+    
+    jj=np.where(m["LOCATION"]==loc)[0]
+    if jj.size<1 :
+        print("LOCATION={} not in metrology???".format(loc))
+        continue
+    j=jj[0]
+    posid=str(m["DEVICE_ID"][j])
+    if posids is not None :
+        if  posid not in posids :
+            continue
+    dx=float(t["X_FP"][i]-m["X_FP"][j])
+    dy=float(t["Y_FP"][i]-m["Y_FP"][j])
+    dist[posid] = np.sqrt(dx**2+dy**2)
+
+for posid in dist.keys() :
+    print("{} dist= {:4.3f} mm".format(posid,dist[posid]))
+distances=np.array([d for d in dist.values()])
+print(distances)
+
+print("number of matched    = {}".format(np.sum(distances>0)))
+print("number with dist<3mm = {}".format(np.sum((distances>0)&(distances<3))))
+print("number with dist<4mm = {}".format(np.sum((distances>0)&(distances<4))))
+print("number with dist<5mm = {}".format(np.sum((distances>0)&(distances<5))))
+print("number with dist<6mm = {}".format(np.sum((distances>0)&(distances<6))))
+print("number of unmatched  = {}".format(np.sum(distances<0)))
+

--- a/bin/desi_fvc_proc
+++ b/bin/desi_fvc_proc
@@ -15,7 +15,7 @@ from desimeter.transform.fvc2fp import FVC2FP
 from desimeter.match import match_same_system
 from desimeter.transform.xy2qs import qs2xy
 from desimeter.fieldmodel import FieldModel
-from desimeter.io import load_metrology,fvc2fp_filename
+from desimeter.io import load_metrology,fvc2fp_filename,fvc_bias_filename
 
 parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                      description="""FVC image processing""")
@@ -52,13 +52,17 @@ parser.add_argument('--min-spots', type = int , default = None, required = False
 parser.add_argument('--max-spots', type = int , default = None, required = False,
                     help = 'max number of detected spots to run')
 parser.add_argument('--no-zbfit', action = 'store_true',
-                    help = 'do not refit the high degree ZB polynomial coefficients, just shift,rotation,magnification')
+                    help = '(deprecated)')
+parser.add_argument('--zbfit', action = 'store_true',
+                    help = 'refit the high degree ZB polynomial coefficients')
 parser.add_argument('--fixed-scale', action = 'store_true',
                     help = 'do not refit the scale')
 parser.add_argument('--fixed-rotation', action = 'store_true',
                     help = 'do not refit the rotation')
 parser.add_argument('--bias', type = str, default = None, required = False,
-                    help = 'use this master bias fits file')
+                    help = 'use this master bias fits file instead of $DESIMETER_DATA/bias.fits if exist')
+parser.add_argument('--no-bias', action = 'store_true',
+                    help = 'do not apply a bias correction (by default, use $DESIMETER_DATA/bias.fits if exist')
 
 args  = parser.parse_args()
 log   = get_logger()
@@ -69,10 +73,18 @@ if not args.outfile.endswith(".csv") :
 
 spots_list=[]
 
-if args.bias :
-    bias = fitsio.read(args.bias).astype(float)
-else :
+if args.no_bias :
     bias = None
+else :
+    if args.bias :
+        bias_filename = args.bias
+    else :
+        bias_filename = fvc_bias_filename()
+    if os.path.isfile(bias_filename) :
+        print("Will subtract bias. Reading {}".format(bias_filename))
+        bias = fitsio.read(bias_filename).astype(float)
+    else :
+        bias = None
 
 filename = args.infile
 if filename.find(".fits")>0 :
@@ -146,7 +158,7 @@ for seqid,spots in enumerate(spots_list) :
 
     tx = FVC2FP.read_jsonfile(fvc2fp_filename())
 
-    tx.fit(spots, update_spots=True, zbfit=(not args.no_zbfit), fixed_scale=args.fixed_scale, fixed_rotation=args.fixed_rotation)
+    tx.fit(spots, update_spots=True, zbfit=(args.zbfit), fixed_scale=args.fixed_scale, fixed_rotation=args.fixed_rotation)
 
     if args.expected_positions is not None :
         log.info("reading expected positions in {}".format(args.expected_positions))

--- a/bin/detect_and_match_moving_positioners
+++ b/bin/detect_and_match_moving_positioners
@@ -91,8 +91,6 @@ ypix1=ypix1[indices_1]
 xpix2=xpix2[indices_2]
 ypix2=ypix2[indices_2]
 
-
-
 # adjust a possible transfo between the two FVC images
 corr=SimpleCorr()
 corr.fit(xpix2,ypix2,xpix1,ypix1)
@@ -105,7 +103,7 @@ xfp2,yfp2=fvc2fp.fvc2fp(xpix2,ypix2)
 dxfp=xfp2-xfp1
 dyfp=yfp2-yfp1
 distfp=np.sqrt(dxfp**2+dyfp**2)
-
+    
 # selection of moving positioners
 detected=(distfp>args.min_move_mm)&(distfp<args.max_move_mm)
 
@@ -219,7 +217,7 @@ if args.plot :
     name="histo-{}".format(os.path.basename(args.outfile).split(".")[0])
 
     plt.figure(name)
-    plt.hist(distfp,bins=100)
+    plt.hist(distfp[distfp<1.],bins=100)
     plt.xlabel("dist (mm)")
     plt.axvline(args.min_move_mm)
     plt.axvline(args.max_move_mm)

--- a/bin/detect_and_match_moving_positioners
+++ b/bin/detect_and_match_moving_positioners
@@ -16,31 +16,14 @@ from desimeter.transform.fvc2fp import FVC2FP
 from desimeter.transform.ptl2fp import fp2ptl
 from desimeter.transform.xy2qs import xy2qs
 from desimeter.averagecoord import average_coordinates
+from desimeter.processfvc import process_fvc
 
-def drawcircle(x,y,r=6.,color='green') :
+def drawcircle(x,y,radius=6.,color='green',alpha=1) :
     a=np.linspace(0,2*np.pi,50)
     ca=np.cos(a)
     sa=np.sin(a)
-    plt.plot(x+r*ca,y+r*sa,"-",color=color)
+    plt.plot(x+radius*ca,y+radius*sa,"-",color=color,alpha=1)
 
-def measure(filename) :
-    if filename.find(".csv")>0 :
-        # already a coordinates table
-        return Table.read(filename)
-    if filename.find(".fits")<0 :
-        print("don't know what to do with",filename)
-        sys.exit(12)
-    outfilename=filename.replace(".fits",".csv")
-    if os.path.isfile(outfilename) :
-        print("using previously processed {}".format(outfilename))
-    else :
-        cmd="desi_fvc_proc -i {} -o {}".format(filename,outfilename)
-        print("running '{}'".format(cmd))
-        errcode=subprocess.call(cmd.split())
-        if errcode != 0 :
-            print("we got an error code = {}".errcode)
-            sys.exit(errcode)
-    return Table.read(outfilename)
 
 parser = argparse.ArgumentParser(description="match positioners by first detecting the moving ones.")
 parser.add_argument('--before-moves', type=str, required=True, nargs="*",
@@ -58,18 +41,20 @@ parser.add_argument('--min-move-mm', type=float, required=False,default=0.05,
                     help='minimum move in mm')
 parser.add_argument('--max-move-mm', type=float, required=False,default=0.5,
                     help='maximum move in mm')
+parser.add_argument('--min-dist-from-center-mm', type=float, required=False,default=3.,
+                    help='minimum distance of fiber from positioner center in mm')
 
 args = parser.parse_args()
 
 moved_positioners = args.positioners.split(",")
 
 
-tables=[ measure(filename) for filename in args.before_moves ]
+tables=[ process_fvc(filename) for filename in args.before_moves ]
 t2 = average_coordinates(tables,"XPIX","YPIX")
 
 # using t1 as reference for output coordinates
 print("INFO: TAKE AS REFERENCE FOR COORDINATES THE IMAGES TAKEN AFTER THE MOVES")
-tables=[ measure(filename) for filename in args.after_moves ]
+tables=[ process_fvc(filename) for filename in args.after_moves ]
 t1 = average_coordinates(tables,"XPIX","YPIX")
 
 xpix1=np.array(t1["XPIX"])
@@ -201,8 +186,14 @@ for k in ["PINHOLE_ID","PTL_SOURCE","PROJ_DISTANCE","PROVENANCE","NOTES","Z_FP",
     if k in spots.dtype.names :
         spots.remove_column(k)
 
-spots.write(args.outfile,overwrite=True)
-print("wrote {} positioners in {}".format(len(spots),args.outfile))
+
+dist_from_center = np.sqrt((spots["X_FP"]-spots["X_FP_METRO"])**2+(spots["Y_FP"]-spots["Y_FP_METRO"])**2)
+n_final = np.sum(dist_from_center>args.min_dist_from_center_mm)
+print("number of detected/matched positioner that are more than {} mm from their center = {}".format(args.min_dist_from_center_mm,n_final))
+if n_final > 0 :
+    selected_spots = spots[(dist_from_center>args.min_dist_from_center_mm)]
+    selected_spots.write(args.outfile,overwrite=True)
+    print("wrote {} positioners in {}".format(len(selected_spots),args.outfile))
 
 if args.plot :
     name="xy-{}".format(os.path.basename(args.outfile).split(".")[0])
@@ -214,10 +205,12 @@ if args.plot :
     dxfp=xfp2-xfp1
     dyfp=yfp2-yfp1
     distfp=np.sqrt(dxfp**2+dyfp**2)
-
+    
     plt.plot(spots["X_FP_METRO"],spots["Y_FP_METRO"],"x",color="green",label="metrology")
     for p in range(len(spots)):
-        drawcircle(spots["X_FP_METRO"][p],spots["Y_FP_METRO"][p])
+        drawcircle(spots["X_FP_METRO"][p],spots["Y_FP_METRO"][p],radius=args.min_dist_from_center_mm,alpha=1)
+        drawcircle(spots["X_FP_METRO"][p],spots["Y_FP_METRO"][p],radius=6,alpha=0.5)
+        
 
     plt.xlabel("xfp")
     plt.ylabel("yfp")

--- a/bin/detect_and_match_moving_positioners
+++ b/bin/detect_and_match_moving_positioners
@@ -1,0 +1,188 @@
+#!/usr/bin/env python
+
+import sys
+import numpy as np
+import matplotlib.pyplot as plt
+from desimeter.io import load_metrology
+from astropy.table import Table
+from desimeter.match import match_same_system
+from desimeter.simplecorr import SimpleCorr
+from desimeter.io import load_metrology,fvc2fp_filename
+from desimeter.transform.fvc2fp import FVC2FP
+from desimeter.transform.ptl2fp import fp2ptl
+from desimeter.transform.xy2qs import xy2qs
+from scipy.spatial import cKDTree as KDTree
+import argparse
+
+parser = argparse.ArgumentParser(description="match positioners by first detecting the moving ones.")
+parser.add_argument('-i', '--infiles', type=str, required=True, nargs=2,
+                    help='path to two input csv file(s) with XPIX YPIX coordinates of spots in two FVC images')
+parser.add_argument('-p', '--positioners', type=str, required=True,
+                    help='comma separated list of positioners that were moved. for instance M08063,M05893')
+parser.add_argument('-o', '--outfile', type=str, required=True,
+                    help='output csv file with matched positioners coordinates and ids')
+parser.add_argument('--plot', action="store_true", help="plot result")
+parser.add_argument('--max-match-radius-mm', type=float, required=False,default=8,
+                    help='maximum metrology match radius in mm')
+parser.add_argument('--min-move-mm', type=float, required=False,default=0.05,
+                    help='minimum move in mm')
+parser.add_argument('--max-move-mm', type=float, required=False,default=0.5,
+                    help='maximum move in mm')
+
+args = parser.parse_args()
+
+moved_positioners = args.positioners.split(",")
+
+def drawcircle(x,y,r=6.,color='green') :
+    a=np.linspace(0,2*np.pi,50)
+    ca=np.cos(a)
+    sa=np.sin(a)
+    plt.plot(x+r*ca,y+r*sa,"-",color=color)
+
+
+filename1=args.infiles[0]
+filename2=args.infiles[1]
+
+
+t1=Table.read(filename1)
+t2=Table.read(filename2)
+xpix1=np.array(t1["XPIX"])
+ypix1=np.array(t1["YPIX"])
+xpix2=np.array(t2["XPIX"])
+ypix2=np.array(t2["YPIX"])
+
+"""
+ok=(ypix1>(5000-0.7*xpix1))
+xpix1=xpix1[ok]
+ypix1=ypix1[ok]
+ok=(ypix2>(5000-0.7*xpix2))
+xpix2=xpix2[ok]
+ypix2=ypix2[ok]
+"""
+
+# match the two sets of spots
+indices_2, distances = match_same_system(xpix1,ypix1,xpix2,ypix2)
+indices_1 = np.arange(len(t1),dtype=int)
+ok=np.where((indices_2>=0)&(distances<50.))[0]
+ok=np.where((indices_2>=0))[0]
+indices_1 = indices_1[ok]
+indices_2 = indices_2[ok]
+distances = distances[ok]
+xpix1=xpix1[indices_1]
+ypix1=ypix1[indices_1]
+xpix2=xpix2[indices_2]
+ypix2=ypix2[indices_2]
+
+# adjust a possible transfo between the two FVC images
+corr=SimpleCorr()
+corr.fit(xpix2,ypix2,xpix1,ypix1)
+xpix2,ypix2=corr.apply(xpix2,ypix2)
+
+# transform from FVC to FP coordinates
+fvc2fp=FVC2FP.read_jsonfile(fvc2fp_filename())
+xfp1,yfp1=fvc2fp.fvc2fp(xpix1,ypix1)
+xfp2,yfp2=fvc2fp.fvc2fp(xpix2,ypix2)
+dxfp=xfp2-xfp1
+dyfp=yfp2-yfp1
+distfp=np.sqrt(dxfp**2+dyfp**2)
+
+# selection of moving positioners
+detected=(distfp>args.min_move_mm)&(distfp<args.max_move_mm)
+
+print("median distance between matches= {} mm".format(np.median(distfp)))
+print("detected moves at xfp = {} yfp = {}".format(xfp1[detected],yfp1[detected]))
+
+# match to positioner centers from metrology
+metrology=load_metrology()
+selection = np.in1d(metrology["DEVICE_ID"],moved_positioners)
+spots=metrology[:][selection]
+xy=np.array([spots["X_FP"],spots["Y_FP"]]).T
+tree = KDTree(xy)
+xy   = np.array([xfp1[detected],yfp1[detected]]).T
+distances,indices = tree.query(xy,k=1)
+
+good=(indices>=0)&(distances<args.max_match_radius_mm)
+bad=np.logical_not(good)
+xfp_detected = xfp1[detected]
+yfp_detected = yfp1[detected]
+xpix_detected = xpix1[detected]
+ypix_detected = ypix1[detected]
+
+ngood=np.sum(good)
+nbad=np.sum(bad)
+
+if nbad>0 :
+    print("WARNING: could not match {} spots".format(nbad))
+
+indices=indices[good]
+distances=distances[good]
+xfp_detected  = xfp_detected[good]
+yfp_detected  = yfp_detected[good]
+xpix_detected = xpix_detected[good]
+ypix_detected = ypix_detected[good]
+
+
+# create output list
+
+spots=spots[indices]
+print("matched to {} at distances of {} mm from centers".format(list(spots["DEVICE_ID"]),distances))
+
+spots["X_FP_METRO"]=spots["X_FP"]+0.
+spots["Y_FP_METRO"]=spots["Y_FP"]+0.
+spots["X_FP"] = xfp_detected
+spots["Y_FP"] = yfp_detected
+spots["XPIX"] = xpix_detected
+spots["YPIX"] = ypix_detected
+xptl = np.zeros(len(spots))
+yptl = np.zeros(len(spots))
+zptl = np.zeros(len(spots))
+for ploc in np.unique(spots["PETAL_LOC"]) :
+    ii=(spots["PETAL_LOC"]==ploc)
+    xptl[ii],yptl[ii],zptl[ii] = fp2ptl(ploc, spots["X_FP"][ii],spots["Y_FP"][ii])
+spots["PTL_X"] = xptl
+spots["PTL_Y"] = yptl
+
+# add Q and S
+q,s = xy2qs(spots["PTL_X"],spots["PTL_Y"])
+spots["Q"] = q
+spots["S"] = s
+
+# add flags
+spots["FLAGS"] = 4*np.ones(len(spots),dtype=int)
+
+#spots.rename_column("DEVICE_ID","POS_ID")
+
+# remove useless columns
+for k in ["PINHOLE_ID","PTL_SOURCE","PROJ_DISTANCE","PROVENANCE","NOTES","Z_FP","X_MNT","Y_MNT","Z_MNT","X_PTL","Y_PTL","Z_PTL"] :
+    if k in spots.dtype.names :
+        spots.remove_column(k)
+
+spots.write(args.outfile,overwrite=True)
+print("wrote",args.outfile)
+
+if args.plot :
+    plt.figure()
+    plt.plot(xfp1,yfp1,"o",alpha=0.5,label=filename1)
+    plt.plot(xfp2,yfp2,"o",alpha=0.5,label=filename2)
+    plt.plot(xfp1[detected],yfp1[detected],"+",color="k",label="detected move")
+
+    dxfp=xfp2-xfp1
+    dyfp=yfp2-yfp1
+    distfp=np.sqrt(dxfp**2+dyfp**2)
+
+    plt.plot(spots["X_FP_METRO"],spots["Y_FP_METRO"],"x",color="green",label="metrology")
+    for p in range(len(spots)):
+        drawcircle(spots["X_FP_METRO"][p],spots["Y_FP_METRO"][p])
+
+    plt.xlabel("xfp")
+    plt.ylabel("yfp")
+    plt.legend()
+
+    plt.figure()
+    plt.hist(distfp,bins=100)
+    plt.xlabel("dist (mm)")
+    plt.axvline(args.min_move_mm)
+    plt.axvline(args.max_move_mm)
+
+
+    plt.show()

--- a/bin/detect_and_match_moving_positioners
+++ b/bin/detect_and_match_moving_positioners
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import sys
+import sys,os
 import numpy as np
 import matplotlib.pyplot as plt
 from desimeter.io import load_metrology
@@ -22,7 +22,7 @@ parser.add_argument('-p', '--positioners', type=str, required=True,
 parser.add_argument('-o', '--outfile', type=str, required=True,
                     help='output csv file with matched positioners coordinates and ids')
 parser.add_argument('--plot', action="store_true", help="plot result")
-parser.add_argument('--max-match-radius-mm', type=float, required=False,default=8,
+parser.add_argument('--max-match-radius-mm', type=float, required=False,default=7,
                     help='maximum metrology match radius in mm')
 parser.add_argument('--min-move-mm', type=float, required=False,default=0.05,
                     help='minimum move in mm')
@@ -39,9 +39,9 @@ def drawcircle(x,y,r=6.,color='green') :
     sa=np.sin(a)
     plt.plot(x+r*ca,y+r*sa,"-",color=color)
 
-
 filename1=args.infiles[0]
 filename2=args.infiles[1]
+print("INFO TAKE AS REFERENCE FOR COORDINATE THE FIRST FILE IN THE ARGS  = ",filename1) 
 
 
 t1=Table.read(filename1)
@@ -59,6 +59,13 @@ ok=(ypix2>(5000-0.7*xpix2))
 xpix2=xpix2[ok]
 ypix2=ypix2[ok]
 """
+"""
+if args.plot :
+    plt.figure()
+    plt.plot(xpix1,ypix1,"o")
+    plt.plot(xpix2,ypix2,"o")
+    plt.show()
+"""
 
 # match the two sets of spots
 indices_2, distances = match_same_system(xpix1,ypix1,xpix2,ypix2)
@@ -72,6 +79,8 @@ xpix1=xpix1[indices_1]
 ypix1=ypix1[indices_1]
 xpix2=xpix2[indices_2]
 ypix2=ypix2[indices_2]
+
+
 
 # adjust a possible transfo between the two FVC images
 corr=SimpleCorr()
@@ -100,6 +109,15 @@ xy=np.array([spots["X_FP"],spots["Y_FP"]]).T
 tree = KDTree(xy)
 xy   = np.array([xfp1[detected],yfp1[detected]]).T
 distances,indices = tree.query(xy,k=1)
+
+unique_indices = np.unique(indices)
+n_duplicates = np.sum(indices>=0)-np.sum(unique_indices>=0)
+if n_duplicates > 0 :
+    for i2 in unique_indices :
+        jj=np.where(indices==i2)[0]
+        if jj.size>1 :
+            kk=np.argsort(distances[jj])
+            indices[jj[kk[1:]]] = -1
 
 good=(indices>=0)&(distances<args.max_match_radius_mm)
 bad=np.logical_not(good)
@@ -158,10 +176,11 @@ for k in ["PINHOLE_ID","PTL_SOURCE","PROJ_DISTANCE","PROVENANCE","NOTES","Z_FP",
         spots.remove_column(k)
 
 spots.write(args.outfile,overwrite=True)
-print("wrote",args.outfile)
+print("wrote {} positioners in {}".format(len(spots),args.outfile))
 
 if args.plot :
-    plt.figure()
+    name="xy-{}-{}".format(os.path.basename(filename1).split(".")[0],os.path.basename(filename2).split(".")[0])
+    plt.figure(name)
     plt.plot(xfp1,yfp1,"o",alpha=0.5,label=filename1)
     plt.plot(xfp2,yfp2,"o",alpha=0.5,label=filename2)
     plt.plot(xfp1[detected],yfp1[detected],"+",color="k",label="detected move")
@@ -178,11 +197,14 @@ if args.plot :
     plt.ylabel("yfp")
     plt.legend()
 
-    plt.figure()
+    name="histo-{}-{}".format(os.path.basename(filename1).split(".")[0],os.path.basename(filename2).split(".")[0])
+    plt.figure(name)
     plt.hist(distfp,bins=100)
     plt.xlabel("dist (mm)")
     plt.axvline(args.min_move_mm)
     plt.axvline(args.max_move_mm)
-
+    expected_move_mm = 3.*5*np.pi/180.
+    plt.axvline(expected_move_mm,linestyle="--")
+    
 
     plt.show()

--- a/bin/detect_and_match_moving_positioners
+++ b/bin/detect_and_match_moving_positioners
@@ -2,21 +2,51 @@
 
 import sys,os
 import numpy as np
+import subprocess
+import argparse
+from scipy.spatial import cKDTree as KDTree
 import matplotlib.pyplot as plt
-from desimeter.io import load_metrology
 from astropy.table import Table
+
+from desimeter.io import load_metrology
 from desimeter.match import match_same_system
 from desimeter.simplecorr import SimpleCorr
 from desimeter.io import load_metrology,fvc2fp_filename
 from desimeter.transform.fvc2fp import FVC2FP
 from desimeter.transform.ptl2fp import fp2ptl
 from desimeter.transform.xy2qs import xy2qs
-from scipy.spatial import cKDTree as KDTree
-import argparse
+from desimeter.averagecoord import average_coordinates
+
+def drawcircle(x,y,r=6.,color='green') :
+    a=np.linspace(0,2*np.pi,50)
+    ca=np.cos(a)
+    sa=np.sin(a)
+    plt.plot(x+r*ca,y+r*sa,"-",color=color)
+
+def measure(filename) :
+    if filename.find(".csv")>0 :
+        # already a coordinates table
+        return Table.read(filename)
+    if filename.find(".fits")<0 :
+        print("don't know what to do with",filename)
+        sys.exit(12)
+    outfilename=filename.replace(".fits",".csv")
+    if os.path.isfile(outfilename) :
+        print("using previously processed {}".format(outfilename))
+    else :
+        cmd="desi_fvc_proc -i {} -o {}".format(filename,outfilename)
+        print("running '{}'".format(cmd))
+        errcode=subprocess.call(cmd.split())
+        if errcode != 0 :
+            print("we got an error code = {}".errcode)
+            sys.exit(errcode)
+    return Table.read(outfilename)
 
 parser = argparse.ArgumentParser(description="match positioners by first detecting the moving ones.")
-parser.add_argument('-i', '--infiles', type=str, required=True, nargs=2,
-                    help='path to two input csv file(s) with XPIX YPIX coordinates of spots in two FVC images')
+parser.add_argument('--before-moves', type=str, required=True, nargs="*",
+                    help='path to one or several FVC image csv file(s) taken before the move')
+parser.add_argument('--after-moves', type=str, required=True, nargs="*",
+                    help='path to one or several FVC image csv file(s) taken after the move')
 parser.add_argument('-p', '--positioners', type=str, required=True,
                     help='comma separated list of positioners that were moved. for instance M08063,M05893')
 parser.add_argument('-o', '--outfile', type=str, required=True,
@@ -33,19 +63,15 @@ args = parser.parse_args()
 
 moved_positioners = args.positioners.split(",")
 
-def drawcircle(x,y,r=6.,color='green') :
-    a=np.linspace(0,2*np.pi,50)
-    ca=np.cos(a)
-    sa=np.sin(a)
-    plt.plot(x+r*ca,y+r*sa,"-",color=color)
 
-filename1=args.infiles[0]
-filename2=args.infiles[1]
-print("INFO TAKE AS REFERENCE FOR COORDINATE THE FIRST FILE IN THE ARGS  = ",filename1) 
+tables=[ measure(filename) for filename in args.before_moves ]
+t2 = average_coordinates(tables,"XPIX","YPIX")
 
+# using t1 as reference for output coordinates
+print("INFO: TAKE AS REFERENCE FOR COORDINATES THE IMAGES TAKEN AFTER THE MOVES")
+tables=[ measure(filename) for filename in args.after_moves ]
+t1 = average_coordinates(tables,"XPIX","YPIX")
 
-t1=Table.read(filename1)
-t2=Table.read(filename2)
 xpix1=np.array(t1["XPIX"])
 ypix1=np.array(t1["YPIX"])
 xpix2=np.array(t2["XPIX"])
@@ -179,10 +205,10 @@ spots.write(args.outfile,overwrite=True)
 print("wrote {} positioners in {}".format(len(spots),args.outfile))
 
 if args.plot :
-    name="xy-{}-{}".format(os.path.basename(filename1).split(".")[0],os.path.basename(filename2).split(".")[0])
+    name="xy-{}".format(os.path.basename(args.outfile).split(".")[0])
     plt.figure(name)
-    plt.plot(xfp1,yfp1,"o",alpha=0.5,label=filename1)
-    plt.plot(xfp2,yfp2,"o",alpha=0.5,label=filename2)
+    plt.plot(xfp1,yfp1,"o",alpha=0.5,label="after the moves")
+    plt.plot(xfp2,yfp2,"o",alpha=0.5,label="before the moves")
     plt.plot(xfp1[detected],yfp1[detected],"+",color="k",label="detected move")
 
     dxfp=xfp2-xfp1
@@ -197,7 +223,8 @@ if args.plot :
     plt.ylabel("yfp")
     plt.legend()
 
-    name="histo-{}-{}".format(os.path.basename(filename1).split(".")[0],os.path.basename(filename2).split(".")[0])
+    name="histo-{}".format(os.path.basename(args.outfile).split(".")[0])
+
     plt.figure(name)
     plt.hist(distfp,bins=100)
     plt.xlabel("dist (mm)")

--- a/bin/plot_fvc_residuals
+++ b/bin/plot_fvc_residuals
@@ -22,7 +22,7 @@ xpix=dict()
 ypix=dict()
 
 filename = args.infile
-    
+
 table=Table.read(filename,format="csv")
 
 if args.expected :
@@ -34,6 +34,7 @@ if args.expected :
     y = table["Y_FP"][ii]
     xm = table["X_FP_EXP"][ii]
     ym = table["Y_FP_EXP"][ii]
+    pid = table["PINHOLE_ID"][ii]
 else :
     ii = np.where((table["LOCATION"]>0)&(table["X_FP_METRO"]!=0))[0]
     if ii.size == 0 :
@@ -43,6 +44,7 @@ else :
     y = table["Y_FP"][ii]
     xm = table["X_FP_METRO"][ii]
     ym = table["Y_FP_METRO"][ii]
+    pid = table["PINHOLE_ID"][ii]
 
 selection = (table["LOCATION"]>0)&(table["X_FP_EXP"]!=0)&(table["PINHOLE_ID"]>0)
 number_of_fiducials = np.unique(table["LOCATION"][selection]).size
@@ -57,7 +59,7 @@ a.set_title(os.path.basename(filename))
 
 a.plot(table["X_FP"],table["Y_FP"],".",alpha=0.5,label="all spots")
 
-if not args.expected : # plotting match to fiducials 
+if not args.expected : # plotting match to fiducials
     # plotting all of FIF and GIF
     metrology = load_metrology()
     selection=(metrology["DEVICE_TYPE"]=="FIF")|(metrology["DEVICE_TYPE"]=="GIF")
@@ -73,7 +75,27 @@ else :
     label = "matched metrology"
     marker = "o"
 a.scatter(xm,ym,marker=marker,edgecolors="orange",facecolors="none",label=label)
-    
+if args.expected :
+    from desimeter.transform.fvc2fp import FVC2FP
+    from desimeter.io import fvc2fp_filename,load_metrology
+    metrology = load_metrology()
+    input_tx = FVC2FP.read_jsonfile(fvc2fp_filename())
+    xpix=np.array([2000.,]) ; ypix=np.array([0.,])
+    xfp1,yfp1 = input_tx.fvc2fp(xpix,ypix)
+    xfp2,yfp2 = input_tx.fvc2fp(xpix+1,ypix)
+    pixel2fp  = np.hypot(xfp2-xfp1, yfp2-yfp1)[0] # mm
+
+    match_radius_pixels = 70
+    match_radius_mm = pixel2fp*match_radius_pixels
+    print("draw match radius = {} pixels = {} mm".format(match_radius_pixels,match_radius_mm))
+    angle=np.linspace(0,2*np.pi,50)
+    ca=match_radius_mm*np.cos(angle)
+    sa=match_radius_mm*np.sin(angle)
+    for xxm,yym,xx,yy,ppid in zip(xm,ym,x,y,pid) :
+        if ppid==0 : # a positioner
+            a.plot(xxm+ca,yym+sa,"-",color="orange")
+            a.plot([xxm,xx],[yym,yy],"-",color="orange")
+
 dx=xm-x
 dy=ym-y
 
@@ -94,7 +116,8 @@ elif jj.size > 0 : # sadly
         if j==jj[0]: label="large residual"
         a.plot(x[j],y[j],"+",color="red",markersize=12,label=label)
 
-a.quiver(x,y,dx,dy)
+if not args.expected :
+    a.quiver(x,y,dx,dy)
 a.set_xlabel("X_FP (mm)")
 a.set_ylabel("Y_FP (mm)")
 
@@ -108,6 +131,11 @@ a.legend(loc="upper left",title=blabla)
 a2=fig.add_subplot(666)
 a2.hist(dist[dist<0.1]*1000.)
 a2.set_xlabel("dist. (um)")
+if args.expected :
+    plt.figure("dist")
+    plt.hist(dist)
+    plt.xlabel("dist. (mm)")
+    print("max(dist)=",np.max(dist))
 
 if False :
     print("Write coordinates of missing or incorrect fiducials")
@@ -122,7 +150,7 @@ if False :
     device_loc=999 # made up
     location=1000*petal_loc+device_loc
     print(table.dtype.names)
-    
+
     # find nearests
     ii=np.where((x-xc)**2+(y-yc)**2<5**2)[0]
     j=np.argmin((x-xc)**2+(y-yc)**2)
@@ -135,7 +163,7 @@ if False :
             dot=c
             c+=1
             if c==4 : c+= 1
-            
+
         print(x[i],y[i])
         print("{line},{petal_id},{petal_loc},{device_loc},{device_type},{dot},0,0,0,0,0,0,'interpolated',0,'none','none',{x},{y},0,{location}".format(line=line,petal_id=petal_id,petal_loc=petal_loc,device_loc=device_loc,device_type=device_type,dot=dot,x=x[i],y=y[i],location=location))
         line += 1
@@ -146,7 +174,7 @@ if False :
     ii=np.where((x-xc)**2+(y-yc)**2<2**2)[0]
     for i in ii :
         print(table[:][i])
-    
+
     device_type="FIF"
     petal_id=8
     petal_loc=4
@@ -161,7 +189,7 @@ if False :
 
     # replacements
     for (xc,yc) in [ (-47.4,41.7) , ( 367.6,176.7) ] :
-        
+
         ii=np.where((x-xc)**2+(y-yc)**2<2**2)[0]
 
         for i in ii :
@@ -181,9 +209,7 @@ if False :
                 for k in metrology.dtype.names :
                     line += ",{}".format(metrology[k][j])
             print(line)
-    
-    
+
+
 
 plt.show()
-
-

--- a/bin/select_groups_of_positioners
+++ b/bin/select_groups_of_positioners
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+
+import numpy as np
+import matplotlib.pyplot as plt
+from desimeter.io import load_metrology
+from astropy.table import Table
+from scipy.spatial import cKDTree as KDTree
+
+
+spots = load_metrology()
+indices=np.where(spots['DEVICE_TYPE']=="POS")[0]
+spots=spots[indices]
+x=spots["X_FP"]
+y=spots["Y_FP"]
+xy=np.array([x,y]).T
+tree = KDTree(xy)
+distances,neighbors = tree.query(xy,k=7)
+
+npos=len(spots)
+groups=[]
+allgroups=[]
+for groupid in range(4) :
+
+    group=[]
+    running_list_of_neighbors=[]
+    for i in range(npos) :
+        if i in running_list_of_neighbors :
+            continue
+        if i in allgroups :
+            continue
+        group.append(i)
+        neighbors_of_this_positioner=neighbors[i,(distances[i]>0)&(distances[i]<12)]
+        for n in neighbors_of_this_positioner :
+            running_list_of_neighbors.append(n)
+
+    groups.append(group)
+    allgroups=np.hstack(groups)
+
+
+for groupid,group in enumerate(groups) :
+    t=Table()
+    t["DEVICE_ID"]=spots["DEVICE_ID"][group]
+    ofilename="group-{}.csv".format(groupid)
+    t.write(ofilename,overwrite=True)
+    print("wrote",ofilename)
+    line="["
+    first=True
+    for did in spots["DEVICE_ID"][group] :
+        if not first : line+=","
+        first=False
+        line+="'{}'".format(did)
+    line += "]"
+    ofilename="group-{}.list".format(groupid)
+    ofile=open(ofilename,"w")
+    ofile.write(line+"\n")
+    ofile.close()
+    print("wrote",ofilename)
+
+
+# validate
+plt.plot(x,y,".",c="gray")
+for groupid in range(4) :
+    filename="group-{}.csv".format(groupid)
+    t=Table().read(filename)
+    selection = np.in1d(spots["DEVICE_ID"],t["DEVICE_ID"])
+    plt.plot(x[selection],y[selection],"o",label="group {}".format(groupid))
+plt.show()

--- a/py/desimeter/averagecoord.py
+++ b/py/desimeter/averagecoord.py
@@ -1,5 +1,4 @@
 import numpy as np
-from scipy.spatial import cKDTree as KDTree
 from desimeter.match import match_same_system
 from desimeter.simplecorr import SimpleCorr
 
@@ -59,7 +58,7 @@ def average_coordinates(tables,xkey,ykey) :
     my=np.mean(yy,axis=0)
     table1[xkey][indices]=mx
     table1[ykey][indices]=my
-    
+
     print("number of entries found in all tables= {}".format(indices.size))
     print("rms({})= {:4.3f}".format(xkey,np.median(xrms)))
     print("rms({})= {:4.3f}".format(ykey,np.median(yrms)))

--- a/py/desimeter/averagecoord.py
+++ b/py/desimeter/averagecoord.py
@@ -1,0 +1,67 @@
+import numpy as np
+from scipy.spatial import cKDTree as KDTree
+from desimeter.match import match_same_system
+from desimeter.simplecorr import SimpleCorr
+
+def average_coordinates(tables,xkey,ykey) :
+    """
+    Average x,y coordinates given by xkey and ykey from a list of astropy tables
+    and return an astropy table with the average coordinates.
+    This function includes a match and a transformation per table.
+    The tables do not necessarily have the same number of entries (in case of false detections).
+    Args
+      tables: list of astropy.Table objects with same columns
+    Returns astropy.Table with same columns as input
+    """
+    table1=None
+    x1=None
+    y1=None
+    indices=None
+    xx=[]
+    yy=[]
+    for table in tables :
+        x2=np.array(table[xkey])
+        y2=np.array(table[ykey])
+        if x1 is None :
+            table1=table
+            x1=x2
+            y1=y2
+            indices=np.arange(len(x1),dtype=int)
+        else :
+            # match the two sets of spots
+            indices_1 = np.arange(len(x1),dtype=int)
+            indices_2, distances = match_same_system(x1,y1,x2,y2)
+            ok=np.where((indices_2>=0)&(distances<5.))[0]
+            indices_1 = indices_1[ok]
+            indices_2 = indices_2[ok]
+            distances = distances[ok]
+            x1=x1[indices_1]
+            y1=y1[indices_1]
+            indices=indices[indices_1]
+            x2=x2[indices_2]
+            y2=y2[indices_2]
+            for i in range(len(xx)) :
+                xx[i]=xx[i][indices_1]
+                yy[i]=yy[i][indices_1]
+            # adjust a possible transfo between the two FVC images
+            corr=SimpleCorr()
+            corr.fit(x2,y2,x1,y1)
+            x2,y2=corr.apply(x2,y2)
+
+        xx.append(x2)
+        yy.append(y2)
+    xx=np.vstack(xx)
+    yy=np.vstack(yy)
+
+    xrms=np.std(xx,axis=0)
+    yrms=np.std(yy,axis=0)
+    mx=np.mean(xx,axis=0)
+    my=np.mean(yy,axis=0)
+    table1[xkey][indices]=mx
+    table1[ykey][indices]=my
+    
+    print("number of entries found in all tables= {}".format(indices.size))
+    print("rms({})= {:4.3f}".format(xkey,np.median(xrms)))
+    print("rms({})= {:4.3f}".format(ykey,np.median(yrms)))
+
+    return table1

--- a/py/desimeter/averagecoord.py
+++ b/py/desimeter/averagecoord.py
@@ -39,7 +39,8 @@ def average_coordinates(tables,xkey,ykey) :
             indices=indices[indices_1]
             x2=x2[indices_2]
             y2=y2[indices_2]
-            for i in range(len(xx)) :
+            n=len(xx)
+            for i in range(n) :
                 xx[i]=xx[i][indices_1]
                 yy[i]=yy[i][indices_1]
             # adjust a possible transfo between the two FVC images

--- a/py/desimeter/io.py
+++ b/py/desimeter/io.py
@@ -32,3 +32,6 @@ def load_petal_alignement():
 
 def fvc2fp_filename():
     return os.path.join(desimeter_data_dir(),'init-fvc2fp.json')
+
+def fvc_bias_filename():
+    return os.path.join(desimeter_data_dir(),'bias.fits')

--- a/py/desimeter/processfvc.py
+++ b/py/desimeter/processfvc.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import subprocess
 from astropy.table import Table
 

--- a/py/desimeter/processfvc.py
+++ b/py/desimeter/processfvc.py
@@ -1,0 +1,22 @@
+import os
+import subprocess
+from astropy.table import Table
+
+def process_fvc(filename) :
+    if filename.find(".csv")>0 :
+        # already a coordinates table
+        return Table.read(filename)
+    if filename.find(".fits")<0 :
+        print("don't know what to do with",filename)
+        sys.exit(12)
+    outfilename=os.path.join("/tmp",os.path.basename(filename.replace(".fits",".csv")))
+    if os.path.isfile(outfilename) :
+        print("using previously processed {}".format(outfilename))
+    else :
+        cmd="desi_fvc_proc -i {} -o {}".format(filename,outfilename)
+        print("running '{}'".format(cmd))
+        errcode=subprocess.call(cmd.split())
+        if errcode != 0 :
+            print("we got an error code = {}".errcode)
+            sys.exit(errcode)
+    return Table.read(outfilename)

--- a/py/desimeter/processfvc.py
+++ b/py/desimeter/processfvc.py
@@ -17,6 +17,6 @@ def process_fvc(filename) :
         print("running '{}'".format(cmd))
         errcode=subprocess.call(cmd.split())
         if errcode != 0 :
-            print("we got an error code = {}".errcode)
+            print("we got an error code = {}".format(errcode))
             sys.exit(errcode)
     return Table.read(outfilename)


### PR DESCRIPTION
PR for new script to detect moving spots between 2 (lists of) FVC images and match them to a group of positions that we asked to move. The PR also includes other utility scripts and routines.
 * new scripts
   * `detect_and_match_moving_positioners` the main script for this PR
   * `select_groups_of_positioners` writes 4 groups of interleaved positioners
   * `average_coordinates` average coordinates of a list on input tables (includes coord. match and fit of residual transform)
   * `compute_distance_from_center` utility script to print distance of fiber tips from positioner centers.
* new functions
  * `averagecoord.py`  average coordinates of a list on input tables (includes coord. match and fit of residual transform)
  * `processfvc.py` function that returns and astropy table from an input file name, which can be either a CSV file or a raw FVC fits image (in which case `desi_fvc_proc` is called and the CSV file written to `/tmp/`). This is not super elegant but it's very useful. 