### PR TITLE
add ok2move script

### DIFF
--- a/bin/ok2move
+++ b/bin/ok2move
@@ -6,6 +6,8 @@ Identify which positioners are ok to move (i.e. not wedged between others)
 
 import sys, os, argparse
 import numpy as np
+import matplotlib
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 from astropy.table import Table
 from astropy.io import fits
@@ -115,7 +117,7 @@ def write_group_html(htmlfile, ids):
         fx.write('</BODY></HTML>\n')
 
 def main():
-    parser = argparse.ArgumentParser(usage = "{prog} [options]")
+    parser = argparse.ArgumentParser(usage = "%(prog)s [options]")
     parser.add_argument("-i", "--input", type=str, required=True,
          help="input table of spots matched to positioners")
     parser.add_argument("-o", "--output", type=str,

--- a/bin/ok2move
+++ b/bin/ok2move
@@ -1,0 +1,185 @@
+#!/usr/bin/env python
+
+"""
+Identify which positioners are ok to move (i.e. not wedged between others)
+"""
+
+import sys, os, argparse
+import numpy as np
+import matplotlib.pyplot as plt
+from astropy.table import Table
+from astropy.io import fits
+from astropy.visualization import ZScaleInterval
+
+def find_neighbors(spots):
+    """
+    Identify 2 nearest neighbors
+
+    Args:
+        spots: table of spots with X_FP and Y_FP columns
+
+    Returns (indices[nspot,2], dist[nspot,2], angle[nspot])
+
+    `indices` is indices in `spots` table of closest 2 neighbors
+    `dist` is distance in mm to closest 2 neighbors;
+    `angle` is opening angle made by neighbors in degrees
+    """
+    nspot = len(spots)
+    indices = np.zeros((nspot, 2), dtype=int)
+    dist = np.zeros((nspot, 2), dtype=float)
+    angle = np.zeros(nspot, dtype=float)
+
+    for i in range(nspot):
+        dx = spots['X_FP'] - spots['X_FP'][i]
+        dy = spots['Y_FP'] - spots['Y_FP'][i]
+        d = np.hypot(dx, dy)
+        j,k = np.argsort(d)[1:3]
+        indices[i] = j,k
+        dist[i] = d[j], d[k]
+
+        v1 = np.array([dx[j], dy[j]])
+        v2 = np.array([dx[k], dy[k]])
+        cosangle = np.dot(v1, v2) / (np.linalg.norm(v1) * np.linalg.norm(v2))
+        angle[i] = np.rad2deg( np.arccos(cosangle) )
+
+    return indices, dist, angle
+
+def ok2move(spots, tooclose=3.5, maxangle=90):
+    """
+    Finds which spots are ok to move based on geometry with neighbors
+
+    Args:
+        spots: table of spots with columns X_FP and Y_FP
+
+    Optional:
+        tooclose: distance in mm to neighbors that is too close to move
+        maxangle: if opening angle is less than this, then ok to move
+
+    Returns boolean array `ok`
+
+    Not ok to move if both neighbors are within `tooclose` and
+    opening angle is > `maxangle`
+    """
+    indices, dist, angle = find_neighbors(spots)
+    ok = (np.sum(dist<tooclose, axis=1)<2) | (angle<maxangle)
+    return ok
+
+def plot_positioner(fvcimage, spots, ispot, ok, outfile, dx=150, dy=150):
+    """
+    Make QA plot of positioners
+    
+    Args:
+        fvcimage : FVC image (preferably front-illuminated)
+        spots : table of spots
+        ispot : index of spot to plot
+        ok : boolean array of ok to move or not per positioner
+        output : output file to write
+
+    Options:
+        dx, dy: image size 2*dx by 2*dy centered on ispot
+    """
+    zscale = ZScaleInterval()
+    x = spots['XPIX'][ispot]
+    y = spots['YPIX'][ispot]
+
+    #- spot near edge of image
+    if int(x)<dx:
+        dx = int(x)
+    if int(y)<dy:
+        dy = int(y)
+
+    fig = plt.figure(figsize=(3,3))
+    plt.subplots_adjust(left=0.02, right=0.98, top=0.92, bottom=0.02)
+    subimg = fvcimage[int(y)-dy:int(y)+dy, int(x)-dx:int(x)+dx]
+    vmin, vmax = zscale.get_limits(subimg)
+    extent = [int(x)-dx, int(x)+dx, int(y)-dy, int(y)+dy]
+    plt.imshow(subimg, vmin=vmin, vmax=vmax, cmap='gray', extent=extent)
+
+    close = (np.abs(spots['XPIX'] - x) < dx) & (np.abs(spots['YPIX'] - y) < dy)
+    xx = spots['XPIX']
+    yy = spots['YPIX']
+
+    plt.plot(xx[close & ok], yy[ok & close], 'go', ms=12)
+    plt.plot(xx[close & ~ok], yy[~ok & close], 'rx', ms=15, mew=4)
+    plt.title(spots['DEVICE_ID'][ispot])
+    plt.axis('off')
+
+    plt.savefig(outfile)
+    plt.close(fig)
+
+def write_group_html(htmlfile, ids):
+    with open(htmlfile, 'w') as fx:
+        fx.write('<HTML><BODY>\n')
+        for device_id in ids:
+            fx.write(f'<IMG SRC="{device_id}.png"/>\n')
+        fx.write('</BODY></HTML>\n')
+
+def main():
+    parser = argparse.ArgumentParser(usage = "{prog} [options]")
+    parser.add_argument("-i", "--input", type=str, required=True,
+         help="input table of spots matched to positioners")
+    parser.add_argument("-o", "--output", type=str,
+        help="output file of positioners ok to move")
+    parser.add_argument("-g", "--groupsize", type=int, default=50,
+         help="Size of groups of positioners for output [default %(default)s]")
+    parser.add_argument("--plotdir", type=str,
+        help="base directory for QA plots (requires --fvcimage too)")
+    parser.add_argument("--fvcimage", type=str,
+        help="input FVC image (required if --plotdir ...)")
+    parser.add_argument("--extname",
+        help="extname of FVC file to use")
+    # parser.add_argument("-v", "--verbose", action="store_true", help="some flag")
+
+    args = parser.parse_args()
+
+    spots = Table.read(args.input)
+
+    #- Remove any fiducial spots in the file
+    keep = spots['PINHOLE_ID'] == 0
+    spots = spots[keep]
+
+    if args.plotdir is not None and args.fvcimage is None:
+        print('ERROR: --plotdir also requires --fvcimage input')
+        sys.exit(1)
+
+    ok = ok2move(spots)
+    okids = spots['DEVICE_ID'][ok]
+
+    if args.output is not None:
+        print(f'Writing groups to {args.output}')
+        outfile = open(args.output, 'w')
+    else:
+        outfile = sys.stdout
+
+    for i in range(len(okids)//args.groupsize):
+        ids = okids[i*args.groupsize:(i+1)*args.groupsize]
+        msg = "group{} = ['{}']\n".format(i, "','".join(ids))
+        outfile.write(msg)
+
+    if args.output is not None:
+        outfile.close()
+
+    if args.plotdir and args.fvcimage:
+        print(f'Writing QA plots to {args.plotdir}')
+        fvcimage = fits.getdata(args.fvcimage, args.extname)
+        if not os.path.isdir(args.plotdir):
+            os.makedirs(args.plotdir)
+        for i in range(len(spots)):
+            outfile = '{}/{}.png'.format(args.plotdir, spots['DEVICE_ID'][i])
+            plot_positioner(fvcimage, spots, i, ok, outfile)
+
+        for i in range(len(okids)//args.groupsize):
+            ids = okids[i*args.groupsize:(i+1)*args.groupsize]
+            htmlfile = f'{args.plotdir}/group{i}.html'
+            write_group_html(htmlfile, ids)
+
+        htmlfile = f'{args.plotdir}/dontmove.html'
+        write_group_html(htmlfile, spots['DEVICE_ID'][~ok])
+
+if __name__ == '__main__':
+    main()
+
+
+
+
+

--- a/bin/ok2move
+++ b/bin/ok2move
@@ -69,7 +69,7 @@ def ok2move(spots, tooclose=3.5, maxangle=90):
 def plot_positioner(fvcimage, spots, ispot, ok, outfile, dx=150, dy=150):
     """
     Make QA plot of positioners
-    
+
     Args:
         fvcimage : FVC image (preferably front-illuminated)
         spots : table of spots
@@ -153,10 +153,11 @@ def main():
     else:
         outfile = sys.stdout
 
-    for i in range(len(okids)//args.groupsize):
+    for i in range(len(okids)//args.groupsize+1):
         ids = okids[i*args.groupsize:(i+1)*args.groupsize]
-        msg = "group{} = ['{}']\n".format(i, "','".join(ids))
-        outfile.write(msg)
+        if len(ids)>0 :
+            msg = "group{} = ['{}']\n".format(i, "','".join(ids))
+            outfile.write(msg)
 
     if args.output is not None:
         outfile.close()
@@ -180,8 +181,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-
-
-
-
-


### PR DESCRIPTION
This PR adds an `ok2move` script that identifies which positioners are likely ok to move based upon the geometry to their two nearest neighbors.  This is intended to be used as part of the recovery for a collision incident where positioners can get trapped between others.  `ok2move` takes an input table of spots matched to positioners (e.g. using PR #102) and prints groups of positioners that are safe to move or optionally writes those lists to a file.  It also optionally can output QA plots of the positioners in each group for a human double check before moving them (takes several minutes to generate all the plots at NERSC).
```
(desi) [ok2move*] desimeter $ ok2move --help
usage: ok2move [options]

optional arguments:
  -h, --help            show this help message and exit
  -i INPUT, --input INPUT
                        input table of spots matched to positioners
  -o OUTPUT, --output OUTPUT
                        output file of positioners ok to move
  -g GROUPSIZE, --groupsize GROUPSIZE
                        Size of groups of positioners for output [default 50]
  --plotdir PLOTDIR     base directory for QA plots (requires --fvcimage too)
  --fvcimage FVCIMAGE   input FVC image (required if --plotdir ...)
  --extname EXTNAME     extname of FVC file to use
```

The output text is intended for cutting-and-pasting to ICS `quick_move`, and is split into groups (adjustable with `--groupsize`):
```
group0 = ['M08246','M08025','M08138','M08020','M08204','M08021','M08023','M08127','M07802','M08239','M08264','M08257','M08258','M07705','M07706','M08022','M08228','M08123','M08260','M08268','M01908','M02388','M01051','M08238','M02049','M08089','M01606','M01057','M08283','M08259','M02145','M05997','M08122','M07672','M08218','M07103','M07551','M08207','M08107','M08475','M01373','M01999','M08008','M08265','M07099','M07703','M07875','M05993','M07813','M07003']
group1 = ['M07810','M08206','M06003','M00628','M01451','M06002','M08277','M06533','M01475','M08081','M02161','M01060','M02278','M01436','M07876','M02224','M08285','M01578','M06537','M08103','M02187','M01437','M01657','M01066','M06535','M02002','M08289','M05669','M08220','M01620','M08305','M08317','M08043','M01409','M08039','M06896','M08173','M08275','M08074','M08215','M02071','M08175','M02220','M07782','M08105','M08316','M06846','M08045','M08046','M08042']
...
```

Example output plots:
![image](https://user-images.githubusercontent.com/218471/85966925-03d82d80-b976-11ea-8acc-898fe1ed558a.png)

In the end, the intended procedure is that one would use this to identify positioners that could be safely moved, rehome those in groups, and then remeasure the location of all positioners and rerun `ok2move` to identify new positioners that are not safe to move.

A potential improvement would be to identify which positioners are safe to move in +phi vs. -phi, but I'm starting with a PR for the minimally useful functionality, while trusting anti-collision checks to prevent further crashes; this PR just focuses the work on positioners that could move.