### PR TITLE
xy2tp improve

### DIFF
--- a/py/desimeter/test/test_pos2ptl.py
+++ b/py/desimeter/test/test_pos2ptl.py
@@ -78,14 +78,14 @@ class TestPos2Ptl(unittest.TestCase):
                       f'error={errors[i][worst]:8.2E}')
                 assert errors[i][worst] < tol
 
-    def test_xy2tp_alts(self):
-        tol = 0.005
+    def test_xy2tp(self):
+        tol = 0.001
         r_test = [2.5, 3.5]
         t_test = [-190, 0, 190]
         p_test = [-10, 10, 170, 190]
         ranges = [[-200, 200], [-20, 200]]
-        t_guess_err = 5
-        t_guess_tol = 20
+        t_guess_err = 3
+        t_guess_tol = 10
         R = [[r1, r2] for r1 in r_test for r2 in r_test]
         tp_test = [[t, p] for t in t_test for p in p_test]
         for r in R:

--- a/py/desimeter/test/test_pos2ptl.py
+++ b/py/desimeter/test/test_pos2ptl.py
@@ -4,6 +4,7 @@ from pkg_resources import resource_filename
 import os
 import numpy as np
 import desimeter.transform.pos2ptl as pos2ptl
+import desimeter.transform.xy2tp as xy2tp
         
 class TestPos2Ptl(unittest.TestCase):
     '''Tests below compare results from this module to a presumed canonical
@@ -77,6 +78,30 @@ class TestPos2Ptl(unittest.TestCase):
                       f'error={errors[i][worst]:8.2E}')
                 assert errors[i][worst] < tol
 
+    def test_xy2tp_alts(self):
+        tol = 0.005
+        r_test = [2.5, 3.5]
+        t_test = [-190, 0, 190]
+        p_test = [-10, 10, 170, 190]
+        ranges = [[-200, 200], [-20, 200]]
+        t_guess_err = 5
+        t_guess_tol = 20
+        R = [[r1, r2] for r1 in r_test for r2 in r_test]
+        tp_test = [[t, p] for t in t_test for p in p_test]
+        for r in R:
+            for tp in tp_test:
+                for sign in [-1, 0, +1]:
+                    xy_test = xy2tp.tp2xy(tp, r)
+                    t_guess = tp[0] + sign*t_guess_err
+                    tp_calc, unreachable = xy2tp.xy2tp(xy_test, r, ranges, t_guess, t_guess_tol)
+                    assert not unreachable
+                    for i in [0, 1]:
+                        error = abs(tp_calc[i] - tp[i])
+                        if error >= tol:
+                            print(f'\nError in xy2tp test:\n error[{i}] = {error:.4f}\n tp_calc = {tp_calc}' +
+                                  f'\n tp_nom = {tp}\n r = {r}\n t_guess = {t_guess}')
+                            print(f' Sample call:\n  xy2tp.xy2tp({xy_test},{r},{ranges},{t_guess},{t_guess_tol})')
+                        assert error < tol 
         
 if __name__ == '__main__':
     unittest.main()

--- a/py/desimeter/test/test_pos2ptl.py
+++ b/py/desimeter/test/test_pos2ptl.py
@@ -85,7 +85,6 @@ class TestPos2Ptl(unittest.TestCase):
         p_test = [-10, 10, 170, 190]
         ranges = [[-200, 200], [-20, 200]]
         t_guess_err = 3
-        t_guess_tol = 10
         R = [[r1, r2] for r1 in r_test for r2 in r_test]
         tp_test = [[t, p] for t in t_test for p in p_test]
         for r in R:
@@ -93,7 +92,7 @@ class TestPos2Ptl(unittest.TestCase):
                 for sign in [-1, 0, +1]:
                     xy_test = xy2tp.tp2xy(tp, r)
                     t_guess = tp[0] + sign*t_guess_err
-                    tp_calc, unreachable = xy2tp.xy2tp(xy_test, r, ranges, t_guess, t_guess_tol)
+                    tp_calc, unreachable = xy2tp.xy2tp(xy_test, r, ranges, t_guess, xy2tp.default_t_guess_tol)
                     assert not unreachable
                     for i in [0, 1]:
                         error = abs(tp_calc[i] - tp[i])

--- a/py/desimeter/test/test_pos2ptl.py
+++ b/py/desimeter/test/test_pos2ptl.py
@@ -99,7 +99,7 @@ class TestPos2Ptl(unittest.TestCase):
                         if error >= tol:
                             print(f'\nError in xy2tp test:\n error[{i}] = {error:.4f}\n tp_calc = {tp_calc}' +
                                   f'\n tp_nom = {tp}\n r = {r}\n t_guess = {t_guess}')
-                            print(f' Sample call:\n  xy2tp.xy2tp({xy_test},{r},{ranges},{t_guess},{t_guess_tol})')
+                            print(f' Sample call:\n  xy2tp.xy2tp({xy_test},{r},{ranges},{t_guess},{xy2tp.default_t_guess_tol})')
                         assert error < tol 
         
 if __name__ == '__main__':

--- a/py/desimeter/transform/pos2ptl.py
+++ b/py/desimeter/transform/pos2ptl.py
@@ -316,9 +316,9 @@ def loc2int(x_loc, y_loc, r1, r2, t_offset, p_offset,
             t_int_guess=None, t_guess_tol=xy2tp.default_t_guess_tol):
     '''Composite of loc2ext followed by ext2int. See docs of those functions
     for more details.
-    
+
     INPUTS:   x_loc, y_loc, r1, r2, t_offset, p_offset, t_guess_int, t_guess_tol
-    
+
     OUTPUTS:  t_int, p_int, unreachable
     '''
     if t_int_guess is None:

--- a/py/desimeter/transform/pos2ptl.py
+++ b/py/desimeter/transform/pos2ptl.py
@@ -138,7 +138,7 @@ def loc2ext(x_loc, y_loc, r1, r2, t_offset, p_offset,
     INPUTS:
         x_loc, y_loc ... positioner local (x,y), as described in module notes
         r1, r2       ... kinematic arms LENGTH_R1 and LENGTH_R2, scalar or vector
-        t_offset, p_offset ... [deg] OFFSET_T and OFFSET_P   
+        t_offset, p_offset ... [deg] OFFSET_T and OFFSET_P
         t_guess_ext and t_guess_tol ... see comments in xy2tp.xy2tp() docstr
 
     OUTPUTS:
@@ -316,9 +316,9 @@ def loc2int(x_loc, y_loc, r1, r2, t_offset, p_offset,
             t_int_guess=None, t_guess_tol=xy2tp.default_t_guess_tol):
     '''Composite of loc2ext followed by ext2int. See docs of those functions
     for more details.
-
+    
     INPUTS:   x_loc, y_loc, r1, r2, t_offset, p_offset, t_guess_int, t_guess_tol
-                
+    
     OUTPUTS:  t_int, p_int, unreachable
     '''
     if t_int_guess is None:

--- a/py/desimeter/transform/pos2ptl.py
+++ b/py/desimeter/transform/pos2ptl.py
@@ -166,6 +166,8 @@ def loc2ext(x_loc, y_loc, r1, r2, t_offset, p_offset,
     r2 = _extend_list(r2, n)
     t_offset = _extend_list(t_offset, n)
     p_offset = _extend_list(p_offset, n)
+    t_guess = _extend_list(t_guess, n)
+    t_guess_tol = _extend_list(t_guess_tol, n)
     t_ext = []
     p_ext = []
     unreachable = []
@@ -177,8 +179,8 @@ def loc2ext(x_loc, y_loc, r1, r2, t_offset, p_offset,
         tp_ext, unreach = xy2tp.xy2tp(xy=[x_loc[i], y_loc[i]],
                                      r=[r1[i], r2[i]],
                                      ranges=ext_ranges,
-                                     t_guess=t_guess,
-                                     t_guess_tol=t_guess_tol,
+                                     t_guess=t_guess[i],
+                                     t_guess_tol=t_guess_tol[i],
                                      )
         t_ext.append(tp_ext[0])
         p_ext.append(tp_ext[1])

--- a/py/desimeter/transform/pos2ptl.py
+++ b/py/desimeter/transform/pos2ptl.py
@@ -161,6 +161,8 @@ def loc2ext(x_loc, y_loc, r1, r2, t_offset, p_offset,
     r2 = _to_list(r2)
     t_offset = _to_list(t_offset)
     p_offset = _to_list(p_offset)
+    t_guess = _to_list(t_guess)
+    t_guess_tol = _to_list(t_guess_tol)
     n = len(x_loc)
     r1 = _extend_list(r1, n)
     r2 = _extend_list(r2, n)

--- a/py/desimeter/transform/pos2ptl.py
+++ b/py/desimeter/transform/pos2ptl.py
@@ -130,14 +130,16 @@ def loc2flat(u_loc, u_offset):
     u_flat = _add_offset(u_loc, u_offset)
     return u_flat
 
-def loc2ext(x_loc, y_loc, r1, r2, t_offset, p_offset):
+def loc2ext(x_loc, y_loc, r1, r2, t_offset, p_offset,
+            t_guess=None, t_guess_tol=xy2tp.default_t_guess_tol):
     '''Converts (x_loc, y_loc) coordinates to (t_ext, p_ext).
     READ THE FINE PRINT: Returned tuple has 3 elements.
 
     INPUTS:
         x_loc, y_loc ... positioner local (x,y), as described in module notes
         r1, r2       ... kinematic arms LENGTH_R1 and LENGTH_R2, scalar or vector
-        t_offset, p_offset ... [deg] OFFSET_T and OFFSET_P
+        t_offset, p_offset ... [deg] OFFSET_T and OFFSET_P   
+        t_guess and t_guess_tol ... see comments in xy2tp.xy2tp() docstr
 
     OUTPUTS:
         t_ext, p_ext ... externally-measured (theta,phi), see module notes
@@ -174,7 +176,10 @@ def loc2ext(x_loc, y_loc, r1, r2, t_offset, p_offset):
                        float(int2ext(_default_p_int_range[1], p_offset[i]))]]
         tp_ext, unreach = xy2tp.xy2tp(xy=[x_loc[i], y_loc[i]],
                                      r=[r1[i], r2[i]],
-                                     ranges=ext_ranges)
+                                     ranges=ext_ranges,
+                                     t_guess=t_guess,
+                                     t_guess_tol=t_guess_tol,
+                                     )
         t_ext.append(tp_ext[0])
         p_ext.append(tp_ext[1])
         unreachable.append(unreach)
@@ -303,14 +308,16 @@ def int2loc(t_int, p_int, r1, r2, t_offset, p_offset):
     x_loc, y_loc = ext2loc(t_ext, p_ext, r1, r2)
     return x_loc, y_loc
 
-def loc2int(x_loc, y_loc, r1, r2, t_offset, p_offset):
+def loc2int(x_loc, y_loc, r1, r2, t_offset, p_offset,
+            t_guess=None, t_guess_tol=xy2tp.default_t_guess_tol):
     '''Composite of loc2ext followed by ext2int. See docs of those functions
     for more details.
 
-    INPUTS:   x_loc, y_loc, r1, r2, t_offset, p_offset
+    INPUTS:   x_loc, y_loc, r1, r2, t_offset, p_offset, t_guess, t_guess_tol
+                
     OUTPUTS:  t_int, p_int, unreachable
     '''
-    t_ext, p_ext, unreachable = loc2ext(x_loc, y_loc, r1, r2, t_offset, p_offset)
+    t_ext, p_ext, unreachable = loc2ext(x_loc, y_loc, r1, r2, t_offset, p_offset, t_guess, t_guess_tol)
     t_int = ext2int(t_ext, t_offset)
     p_int = ext2int(p_ext, p_offset)
     return t_int, p_int, unreachable
@@ -327,16 +334,17 @@ def int2ptl(t_int, p_int, r1, r2, t_offset, p_offset, x_offset, y_offset):
     x_ptl, y_ptl = flat2ptl(x_flat,y_flat)
     return x_ptl, y_ptl
 
-def ptl2int(x_ptl, y_ptl, r1, r2, t_offset, p_offset, x_offset, y_offset):
+def ptl2int(x_ptl, y_ptl, r1, r2, t_offset, p_offset, x_offset, y_offset,
+            t_guess=None, t_guess_tol=xy2tp.default_t_guess_tol):
     '''Composite of ptl2flat flat2loc loc2ext ext2int.
 
-    INPUTS:   x_ptl, y_ptl, r1, r2, t_offset, p_offset, x_offset, y_offset
+    INPUTS:   x_ptl, y_ptl, r1, r2, t_offset, p_offset, x_offset, y_offset, t_guess, t_guess_tol
     OUTPUTS:  t_int, p_int, unreachable
     '''
     x_flat, y_flat = ptl2flat(x_ptl, y_ptl)
     x_loc = flat2loc(x_flat, x_offset)
     y_loc = flat2loc(y_flat, y_offset)
-    t_int, p_int, unreachable = loc2int(x_loc, y_loc, r1, r2, t_offset, p_offset)
+    t_int, p_int, unreachable = loc2int(x_loc, y_loc, r1, r2, t_offset, p_offset, t_guess, t_guess_tol)
     return t_int, p_int, unreachable
 
 def _to_numpy(u):

--- a/py/desimeter/transform/xy2tp.py
+++ b/py/desimeter/transform/xy2tp.py
@@ -17,7 +17,7 @@ import sys
 try:
     import posconstants as pc
     default_t_guess_tol = pc.default_t_guess_tol
-except:
+except ModuleNotFoundError :
     default_t_guess_tol = 30.0
 epsilon = sys.float_info.epsilon
 
@@ -51,7 +51,7 @@ def xy2tp(xy, r, ranges, t_guess=None, t_guess_tol=default_t_guess_tol):
 
     In cases where unreachable == True, the returned tp value will be a
     closest possible approach to the unreachable point requested at xy.
-    
+
     Guess value for theta (when provided by caller) will be used to disambiguate
     between mathematically possible alternate (t,p) pairs. If not provided, then
     the function will pick a pair for which p is within [0,180].
@@ -83,15 +83,15 @@ def xy2tp(xy, r, ranges, t_guess=None, t_guess_tol=default_t_guess_tol):
     arccos_arg = min(arccos_arg, +1.0) # deal with slight numeric errors where arccos_arg comes back like +1.0000000000000002
     P = math.acos(arccos_arg)
     T = angle - math.atan2(r2*math.sin(P), r1 + r2*math.cos(P))
-    
+
     # primary configuration of the arms
     TP = [math.degrees(T), math.degrees(P)]
     TP, range_fail = _wrap_TP_into_ranges(TP, ranges)
-    
+
     # test alternate configurations
     if t_guess != None:
         options = [{'TP':TP, 'range_fail':range_fail}]
-        
+
         # reflecting the arms across vector (X,Y)
         tx = r1*math.cos(T)  # i.e., vector to phi fulcrum, which will be reflected
         ty = r1*math.sin(T)
@@ -105,14 +105,14 @@ def xy2tp(xy, r, ranges, t_guess=None, t_guess_tol=default_t_guess_tol):
         TP_alt = [math.degrees(T_alt), math.degrees(P_alt)]
         TP_alt, range_fail_alt = _wrap_TP_into_ranges(TP_alt, ranges)
         options.append({'TP':TP_alt, 'range_fail':range_fail_alt})
-        
+
         # rotating theta by +/-360 deg
         for center_TP in [opt['TP'] for opt in options]:
             TP_alts = [[center_TP[0] + wrap, center_TP[1]] for wrap in [-360.0, 360.0]]
             for TP_alt in TP_alts:
                 TP_alt, range_fail_alt = _wrap_TP_into_ranges(TP_alt, ranges)
                 options.append({'TP':TP_alt, 'range_fail':range_fail_alt})
-        
+
         # selection
         for opt in options:
             opt['closeness'] = abs(opt['TP'][0] - t_guess)
@@ -125,16 +125,16 @@ def xy2tp(xy, r, ranges, t_guess=None, t_guess_tol=default_t_guess_tol):
             options.sort(key=lambda x: x['range_fail'])  # primary sort
             TP = options[0]['TP']
             range_fail = options[0]['range_fail']
-            
+
     unreachable |= range_fail
     return tuple(TP), unreachable
 
 def _wrap_TP_into_ranges(tp, ranges):
     '''Call _wrap_into_range for theta and phi angles.
-    
+
     INPUT:  tp ... [theta, phi], units deg
             ranges ... see xy2tp docstr, units deg
-            
+
     OUTPUT: TP ... wrapped angles
             unreachable ... boolean, true if not possible to put either angle in range
     '''
@@ -149,11 +149,11 @@ def _wrap_TP_into_ranges(tp, ranges):
 def _wrap_into_range(angle, range_min, range_max):
     '''Check +/-360 deg phase wraps (as necessary) to put angle within the
     argued range. All units in radians.
-    
+
     INPUT:  angle ... value to be checked
             range_min ... lowest allowed
             range_max ... highest allowed
-    
+
     OUTPUT: new ... new angle
             unreachable ... boolean, True if not not possible to put angle in range
     '''

--- a/py/desimeter/transform/xy2tp.py
+++ b/py/desimeter/transform/xy2tp.py
@@ -53,8 +53,6 @@ def xy2tp(xy, r, ranges):
     In cases where unreachable == True, the returned tp value will be a
     closest possible approach to the unreachable point requested at xy.
     """
-    theta_centralizing_err_tol = 1e-4 # within this much xy error allowance, adjust theta toward center of its range
-    n_theta_centralizing_iters = 3 # number of points to try when attempting to centralize theta
     numeric_contraction = epsilon*10 # slight contraction to avoid numeric divide-by-zero type of errors
     x, y, r1, r2 = xy[0], xy[1], r[0], r[1]
     unreachable = False
@@ -62,8 +60,8 @@ def xy2tp(xy, r, ranges):
     # adjust targets within reachable annulus
     hypot = (x**2.0 + y**2.0)**0.5
     angle = math.atan2(y, x)
-    outer = r[0] + r[1]
-    inner = abs(r[0] - r[1])
+    outer = r1 + r2
+    inner = abs(r1 - r2)
     if hypot > outer or hypot < inner:
         unreachable = True
     inner += numeric_contraction
@@ -97,18 +95,6 @@ def xy2tp(xy, r, ranges):
             if TP[i] > range_max:
                 TP[i] = range_max
                 unreachable = True
-
-    # centralize theta
-    T_ctr = (ranges[0][0] + ranges[0][1])/2.0
-    T_options = linspace(TP[0], T_ctr, n_theta_centralizing_iters)
-    for T_try in T_options:
-        xy_try = tp2xy([T_try, TP[1]], r)
-        x_err = xy_try[0] - X
-        y_err = xy_try[1] - Y
-        vector_err = (x_err**2.0 + y_err**2.0)**0.5
-        if vector_err <= theta_centralizing_err_tol:
-            TP[0] = T_try
-            break
 
     return tuple(TP), unreachable
 

--- a/py/desimeter/transform/xy2tp.py
+++ b/py/desimeter/transform/xy2tp.py
@@ -24,7 +24,7 @@ local, etc.)
 import math
 import sys
 epsilon = sys.float_info.epsilon
-default_t_guess_tol = 20.0
+default_t_guess_tol = 10.0
 
 def tp2xy(tp, r):
     """Converts TP angles into XY cartesian coordinates, where arm lengths

--- a/py/desimeter/transform/xy2tp.py
+++ b/py/desimeter/transform/xy2tp.py
@@ -97,8 +97,3 @@ def xy2tp(xy, r, ranges):
                 unreachable = True
 
     return tuple(TP), unreachable
-
-def linspace(start,stop,num):
-    """Return a list of floats linearly spaced from start to stop (inclusive).
-    List has num elements."""
-    return [i*(stop-start)/(num-1)+start for i in range(num)]

--- a/py/desimeter/transform/xy2tp.py
+++ b/py/desimeter/transform/xy2tp.py
@@ -24,7 +24,7 @@ local, etc.)
 import math
 import sys
 epsilon = sys.float_info.epsilon
-default_t_guess_tol = 10.0
+default_t_guess_tol = 30.0
 
 def tp2xy(tp, r):
     """Converts TP angles into XY cartesian coordinates, where arm lengths

--- a/py/desimeter/transform/xy2tp.py
+++ b/py/desimeter/transform/xy2tp.py
@@ -3,22 +3,13 @@
 This module provides the fundamental coordinate transformations between fiber
 positioner (theta, phi) angles and an (x, y) cartesian space.
 
-It is a direct copy of static methods from the postransforms module on SVN:
-    /code/focalplane/plate_control/trunk/petal/postransforms.py
-    SVN revision r131291
+It is kept manually synchronized with a file of the same name in the online
+instrument code:
+    /code/focalplane/plate_control/<some_branch>/petal/xy2tp.py
 
-That module generally works with python lists and the math module, rather
+This module generally works with python lists and the math module, rather
 numpy arrays. That is done for speed, since numpy carries tremendous overhead
-in the more atomic operations done on the instrument.
-
-Since desimeter tends to work with numpy arrays, the usage of these functions
-is not expected to be done directly. Rather one will use the thin wrappers
-in the pos2ptl module.
-
-Another reason for the wrappers is that the pos2ptl module uses some more
-specific nomenclature. I.e. there are different kinds of "tp" (internally-
-tracked vs externally-measured) and different kinds of xy (petal vs flat vs
-local, etc.)
+in the small, atomic operations done when operating the instrument.
 """
 
 import math

--- a/py/desimeter/transform/xy2tp.py
+++ b/py/desimeter/transform/xy2tp.py
@@ -108,19 +108,33 @@ def xy2tp(xy, r, ranges, t_guess=None, t_guess_tol=20.0):
     # wrap angles into travel ranges
     for i in [0, 1]:
         range_min, range_max = min(ranges[i]), max(ranges[i])
-        if TP[i] < range_min: # try +360 phase wrap
-            TP[i] += math.floor((range_max - TP[i])/360.0)*360.0
-            if TP[i] < range_min:
-                TP[i] = range_min
-                unreachable = True
-        elif TP[i] > range_max: # try -360 phase wrap
-            TP[i] -= math.floor((TP[i] - range_min)/360.0)*360.0
-            if TP[i] > range_max:
-                TP[i] = range_max
-                unreachable = True
-    
-    # temporary, for debug
-    if TP[1] < 0 or TP[1] > 180:
-        print(TP[1])
+        TP[i], fail = _wrap_into_range(TP[i], range_min, range_max)
+        if fail:
+            unreachable = True
 
     return tuple(TP), unreachable
+
+def _wrap_into_range(angle, range_min, range_max):
+    '''Check +/-360 deg phase wraps (as necessary) to put angle within the
+    argued range. All units in deg.
+    
+    INPUT:  angle ... value to be checked
+            range_min ... lowest allowed
+            range_max ... highest allowed
+    
+    OUTPUT: new ... new angle
+            unreachable ... boolean, True if not not possible to put angle in range
+    '''
+    new = angle
+    unreachable = False
+    if new < range_min: # try +360 phase wrap
+        new += math.floor((range_max - new)/360.0)*360.0
+        if new < range_min:
+            new = range_min
+            unreachable = True
+    elif new > range_max: # try -360 phase wrap
+        new -= math.floor((new - range_min)/360.0)*360.0
+        if new > range_max:
+            new = range_max
+            unreachable = True
+    return new, unreachable

--- a/py/desimeter/transform/xy2tp.py
+++ b/py/desimeter/transform/xy2tp.py
@@ -24,6 +24,7 @@ local, etc.)
 import math
 import sys
 epsilon = sys.float_info.epsilon
+default_t_guess_tol = 20.0
 
 def tp2xy(tp, r):
     """Converts TP angles into XY cartesian coordinates, where arm lengths
@@ -38,7 +39,7 @@ def tp2xy(tp, r):
     y = r[0] * math.sin(t) + r[1] * math.sin(t_plus_p)
     return x, y
 
-def xy2tp(xy, r, ranges, t_guess=None, t_guess_tol=20.0):
+def xy2tp(xy, r, ranges, t_guess=None, t_guess_tol=default_t_guess_tol):
     """Converts XY cartesian coordinates into TP angles, where arm lengths
      associated with angles theta and phi are respectively r[1] and r[2].
 
@@ -46,11 +47,11 @@ def xy2tp(xy, r, ranges, t_guess=None, t_guess_tol=20.0):
                r ... [central arm length, eccentric arm length]
           ranges ... [[min(theta), max(theta)], [min(phi), max(phi)]]
          t_guess ... optional guess at approx theta expected, unit degrees
-     t_guess_tol ... default=20, unit degrees
+     t_guess_tol ... ignore t_guess if more than this far from mathematically
+                     possible theta options, default=20, unit degrees
 
     OUTPUTS:  tp ... [theta,phi], unit degrees
-     unreachable ... boolean, True if the requested xy cannot be reached
-                     by any tp
+     unreachable ... boolean, True if the requested xy cannot be reached by any tp
 
     In cases where unreachable == True, the returned tp value will be a
     closest possible approach to the unreachable point requested at xy.

--- a/py/desimeter/transform/xy2tp.py
+++ b/py/desimeter/transform/xy2tp.py
@@ -14,8 +14,13 @@ in the small, atomic operations done when operating the instrument.
 
 import math
 import sys
+try:
+    import posconstants as pc
+    default_t_guess_tol = pc.default_t_guess_tol
+except:
+    default_t_guess_tol = 30.0
 epsilon = sys.float_info.epsilon
-default_t_guess_tol = 30.0
+
 
 def tp2xy(tp, r):
     """Converts TP angles into XY cartesian coordinates, where arm lengths


### PR DESCRIPTION
Added ability to provide a "guess" value for theta when converting from xy to tp. This allows the code to resolve the ambigous mirror image configurations of the kinematic arms. Previously we have always just used the case that puts phi within [0,180]. This is not a generally true fact, but can only be resolved when we have extra contextual knowledge. I tested the code both on cases I constructed in the unit test module, and on new arc data I measured for five positioners. I will put a description of this change together in a powerpoint soon and show it Friday or Monday, I expect.