### PR TITLE
xy2tp phi wrapping error

### DIFF
--- a/py/desimeter/test/test_pos2ptl.py
+++ b/py/desimeter/test/test_pos2ptl.py
@@ -79,8 +79,9 @@ class TestPos2Ptl(unittest.TestCase):
                 assert errors[i][worst] < tol
 
     def test_xy2tp(self):
+        tol = 0.001
+        n_tested = 0
         def check_xy2tp(tp_nom, xy_test, r, ranges, t_guess, t_guess_tol):
-            tol = 0.001
             tp_calc, unreachable = xy2tp.xy2tp(xy_test, r, ranges, t_guess, t_guess_tol)
             assert not unreachable
             for i in [0, 1]:
@@ -103,6 +104,7 @@ class TestPos2Ptl(unittest.TestCase):
                     xy_test = xy2tp.tp2xy(tp_nom, r)
                     t_guess = tp_nom[0] + sign*t_guess_err
                     check_xy2tp(tp_nom, xy_test, r, ranges, t_guess, xy2tp.default_t_guess_tol)
+                    n_tested += 1
         # specific cases known to have caused issues in the past
         tp_nom =  {'a':(2.27556, 173.80926), 'b':(-0.29619, 173.23958), }
         xy_test = {'a':(0.00464,   0.32395), 'b':( 0.02268,   0.35304), }
@@ -113,6 +115,8 @@ class TestPos2Ptl(unittest.TestCase):
         t_guess_tol = {'a':30, 'b':30}
         for k in tp_nom:
             check_xy2tp(tp_nom[k], xy_test[k], r[k], ranges[k], t_guess[k], t_guess_tol[k])
+            n_tested += 1
+        print(f'\nxy2tp tested on {n_tested} points:\n err tol={tol}\n All ok')
             
 
 if __name__ == '__main__':

--- a/py/desimeter/test/test_pos2ptl.py
+++ b/py/desimeter/test/test_pos2ptl.py
@@ -79,8 +79,18 @@ class TestPos2Ptl(unittest.TestCase):
                 assert errors[i][worst] < tol
 
     def test_xy2tp(self):
-        tol = 0.001
-        r_test = [2.5, 3.5]
+        def check_xy2tp(tp_nom, xy_test, r, ranges, t_guess, t_guess_tol):
+            tol = 0.001
+            tp_calc, unreachable = xy2tp.xy2tp(xy_test, r, ranges, t_guess, t_guess_tol)
+            assert not unreachable
+            for i in [0, 1]:
+                error = abs(tp_calc[i] - tp_nom[i])
+                if error >= tol:
+                    print(f'\nError in xy2tp test:\n error[{i}] = {error:.4f}\n tp_calc = {tp_calc}' +
+                          f'\n tp_nom = {tp_nom}\n r = {r}\n t_guess = {t_guess}')
+                    print(f' Sample call:\n  xy2tp.xy2tp({xy_test},{r},{ranges},{t_guess},{xy2tp.default_t_guess_tol})')
+                assert error < tol
+        r_test = [2.5, 3.0, 3.5]
         t_test = [-190, 0, 190]
         p_test = [-10, 10, 170, 190]
         ranges = [[-200, 200], [-20, 200]]
@@ -88,20 +98,22 @@ class TestPos2Ptl(unittest.TestCase):
         R = [[r1, r2] for r1 in r_test for r2 in r_test]
         tp_test = [[t, p] for t in t_test for p in p_test]
         for r in R:
-            for tp in tp_test:
+            for tp_nom in tp_test:
                 for sign in [-1, 0, +1]:
-                    xy_test = xy2tp.tp2xy(tp, r)
-                    t_guess = tp[0] + sign*t_guess_err
-                    tp_calc, unreachable = xy2tp.xy2tp(xy_test, r, ranges, t_guess, xy2tp.default_t_guess_tol)
-                    assert not unreachable
-                    for i in [0, 1]:
-                        error = abs(tp_calc[i] - tp[i])
-                        if error >= tol:
-                            print(f'\nError in xy2tp test:\n error[{i}] = {error:.4f}\n tp_calc = {tp_calc}' +
-                                  f'\n tp_nom = {tp}\n r = {r}\n t_guess = {t_guess}')
-                            print(f' Sample call:\n  xy2tp.xy2tp({xy_test},{r},{ranges},{t_guess},{xy2tp.default_t_guess_tol})')
-                        assert error < tol 
-        
+                    xy_test = xy2tp.tp2xy(tp_nom, r)
+                    t_guess = tp_nom[0] + sign*t_guess_err
+                    check_xy2tp(tp_nom, xy_test, r, ranges, t_guess, xy2tp.default_t_guess_tol)
+        # specific cases known to have caused issues in the past
+        tp_nom = [(2.27556, 173.80926),]
+        xy_test = [(0.00464, 0.32395),]
+        r = [[3.0, 3.0],]
+        ranges = [[[-200.0, 200.0], [-3.6253, 185.0]],]
+        t_guess = [-183.946,]
+        t_guess_tol = [30,]
+        for i in range(len(xy_test)):
+            check_xy2tp(tp_nom[i], xy_test[i], r[i], ranges[i], t_guess[i], t_guess_tol[i])
+            
+
 if __name__ == '__main__':
     unittest.main()
     

--- a/py/desimeter/test/test_pos2ptl.py
+++ b/py/desimeter/test/test_pos2ptl.py
@@ -104,14 +104,15 @@ class TestPos2Ptl(unittest.TestCase):
                     t_guess = tp_nom[0] + sign*t_guess_err
                     check_xy2tp(tp_nom, xy_test, r, ranges, t_guess, xy2tp.default_t_guess_tol)
         # specific cases known to have caused issues in the past
-        tp_nom = [(2.27556, 173.80926),]
-        xy_test = [(0.00464, 0.32395),]
-        r = [[3.0, 3.0],]
-        ranges = [[[-200.0, 200.0], [-3.6253, 185.0]],]
-        t_guess = [-183.946,]
-        t_guess_tol = [30,]
-        for i in range(len(xy_test)):
-            check_xy2tp(tp_nom[i], xy_test[i], r[i], ranges[i], t_guess[i], t_guess_tol[i])
+        tp_nom =  {'a':(2.27556, 173.80926), 'b':(-0.29619, 173.23958), }
+        xy_test = {'a':(0.00464,   0.32395), 'b':( 0.02268,   0.35304), }
+        r = {'a':[3.0, 3.0], 'b':[3.0, 3.0], }
+        ranges = {'a': [[-200.0, 200.0], [-3.6253, 185.0]],
+                  'b': [[-195.95685, 195.95685], [-3.92183, 185.0]], }
+        t_guess = {'a':-183.946, 'b':-186.89834}
+        t_guess_tol = {'a':30, 'b':30}
+        for k in tp_nom:
+            check_xy2tp(tp_nom[k], xy_test[k], r[k], ranges[k], t_guess[k], t_guess_tol[k])
             
 
 if __name__ == '__main__':

--- a/py/desimeter/transform/xy2tp.py
+++ b/py/desimeter/transform/xy2tp.py
@@ -107,7 +107,10 @@ def xy2tp(xy, r, ranges, t_guess=None, t_guess_tol=default_t_guess_tol):
         options.append({'TP':TP_alt, 'range_fail':range_fail_alt})
 
         # rotating theta by +/-360 deg
-        for center_TP in [opt['TP'] for opt in options]:
+        for opt in options.copy():
+            if opt['range_fail']:
+                continue  # because cannot base a viable alternate on a config that doesn't achieve xy
+            center_TP = opt['TP']
             TP_alts = [[center_TP[0] + wrap, center_TP[1]] for wrap in [-360.0, 360.0]]
             for TP_alt in TP_alts:
                 TP_alt, range_fail_alt = _wrap_TP_into_ranges(TP_alt, ranges)


### PR DESCRIPTION
This PR corrects an error in xy2tp that was revealed today (2020-08-28) during Petal0 tests. I also added specific error cases from the Petal0 testing today to the unit test. With this two line fix, those cases pass now.

DETAILS:
The fix is very simple, but the sequence of events when the bug occurs takes many words to describe!

When operating in theta_guess mode, xy2tp generates possible alternates for (t,p) in three steps:

 a. Law of cosines calc --> (t,p) such that p within [0, 180]
 b. Reflect coords from (c) across a line from origin through (x,y)
 c. For each of these options, generate two more options, wrapping theta by +/-360 deg

Subsequently the best option (nearest to t_guess without exceeding range limits or t_guess_tol) is selected.

At each step of a, b, c, the proposed (t,p) is checked against range limits. In cases where the limits would be exceeded, the limit value itself is used, and a boolean is generated stating "range_fail".

The bug occurs when in some cases when we have a range_fail at step (a) or (b). In (c) additional (t,p) options would be generated based on these truncated values. If this occurs at the same time that theta is > 180 or < -180, and is opposite from t_guess --- then we have a loophole --- some new (c) option, might *unwrap* into a plausible range. However it would be starting its unwrap from a truncated value, and thus end up in the wrong place.

It's quite complicated to describe this chain of events --- and was tricky to find during debugging today! But in fact the solution is very simple 2 lines of code, which just check for a range_fail in (a) or (b), and if so don't try any secondary wrapped options with that (t,p) as a basis.