### PR TITLE
Turbulence opt

### DIFF
--- a/bin/desi_fvc_proc
+++ b/bin/desi_fvc_proc
@@ -17,6 +17,7 @@ from desimeter.transform.xy2qs import qs2xy
 from desimeter.fieldmodel import FieldModel
 from desimeter.io import load_metrology,fvc2fp_filename,fvc_bias_filename
 from desimeter.spotmatch import spotmatch
+from desimeter.turbulence import correct
 
 parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                      description="""FVC image processing""")
@@ -70,6 +71,8 @@ parser.add_argument('--no-bias', action = 'store_true',
                     help = 'do not apply a bias correction (by default, use $DESIMETER_DATA/bias.fits if exist')
 parser.add_argument('--use-spotmatch', action = 'store_true',
                     help = 'use spotmatch instead of desimeter code for matching positioners and fiducials (requires the program match_positions installed and in the PATH)')
+parser.add_argument('--turbulence-correction', action = 'store_true',
+                    help = 'correct for turbulence assuming offsets between measured and expected coordinates are not spatially correlated. Only used in conjunction with option --expected-positions.')
 
 args  = parser.parse_args()
 log   = get_logger()
@@ -197,7 +200,7 @@ for seqid,spots in enumerate(spots_list) :
     if args.expected_positions is not None :
         log.info("reading expected positions in {}".format(args.expected_positions))
         expected_pos = Table.read(args.expected_positions) # auto-magically guess format
-        if not "X_FP_EXP" in expected_pos.keys() :
+        if not "X_FP" in expected_pos.keys() :
             if "EXP_Q_0" in  expected_pos.keys() :
                 log.info("EXP_Q_0,EXP_S_0 -> X_FP,Y_FP")
                 x,y = qs2xy(q=expected_pos["EXP_Q_0"],s=expected_pos["EXP_S_0"])
@@ -246,6 +249,19 @@ for seqid,spots in enumerate(spots_list) :
                 else :
                     spots[k] = np.zeros(len(spots))
             spots[k][selection]=expected_pos[k][indices_of_expected_pos]
+
+    if args.expected_positions is not None and args.turbulence_correction :
+        log.info("Turbulence correction ...")
+        selection=(spots["LOCATION"]>=0)&(spots["X_FP_EXP"]!=0)&(spots["Y_FP_EXP"]!=0) # matched
+        new_x,new_y = correct(spots["X_FP"][selection],spots["Y_FP"][selection],spots["X_FP_EXP"][selection],spots["Y_FP_EXP"][selection])
+        rms_before = np.sqrt(np.mean((spots["X_FP"][selection]-spots["X_FP_EXP"][selection])**2+(spots["Y_FP"][selection]-spots["Y_FP_EXP"][selection])**2))
+        rms_after  = np.sqrt(np.mean((new_x-spots["X_FP_EXP"][selection])**2+(new_y-spots["Y_FP_EXP"][selection])**2))
+        log.info("rms(measured-expected)={:5.4f}mm rms(corrected-expected)={:5.4f}mm ".format(rms_before,rms_after))
+        if rms_before < rms_after :
+            log.warning("turbulence correction does not reduce the rms?")
+            # apply it anyway because there might be a good reason for this
+        spots["X_FP"][selection] = new_x
+        spots["Y_FP"][selection] = new_y
 
     # for spots with metrology X_FP_EXP=X_FP_METRO
     selection = (spots["X_FP_METRO"]!=0)

--- a/bin/desi_fvc_proc
+++ b/bin/desi_fvc_proc
@@ -17,7 +17,7 @@ from desimeter.transform.xy2qs import qs2xy
 from desimeter.fieldmodel import FieldModel
 from desimeter.io import load_metrology,fvc2fp_filename,fvc_bias_filename
 from desimeter.spotmatch import spotmatch
-from desimeter.turbulence import correct
+from desimeter.turbulence import correct,correct_with_pol
 
 parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                      description="""FVC image processing""")
@@ -73,6 +73,8 @@ parser.add_argument('--use-spotmatch', action = 'store_true',
                     help = 'use spotmatch instead of desimeter code for matching positioners and fiducials (requires the program match_positions installed and in the PATH)')
 parser.add_argument('--turbulence-correction', action = 'store_true',
                     help = 'correct for turbulence assuming offsets between measured and expected coordinates are not spatially correlated. Only used in conjunction with option --expected-positions.')
+parser.add_argument('--turbulence-correction-with-pol', action = 'store_true',
+                    help = 'correct for turbulence assuming offsets between measured and expected coordinates are not spatially correlated. Only used in conjunction with options --expected-positions, uses polynomial method instead of Gaussian processes ')
 
 args  = parser.parse_args()
 log   = get_logger()
@@ -250,10 +252,18 @@ for seqid,spots in enumerate(spots_list) :
                     spots[k] = np.zeros(len(spots))
             spots[k][selection]=expected_pos[k][indices_of_expected_pos]
 
-    if args.expected_positions is not None and args.turbulence_correction :
-        log.info("Turbulence correction ...")
+    if args.expected_positions is not None and ( args.turbulence_correction or args.turbulence_correction_with_pol ):
+
+        if args.turbulence_correction_with_pol :
+            log.info("Turbulence correction (local polynomial fit) ...")
+        else :
+            log.info("Turbulence correction (gaussian processes) ...")
         selection=(spots["LOCATION"]>=0)&(spots["X_FP_EXP"]!=0)&(spots["Y_FP_EXP"]!=0) # matched
-        new_x,new_y = correct(spots["X_FP"][selection],spots["Y_FP"][selection],spots["X_FP_EXP"][selection],spots["Y_FP_EXP"][selection])
+
+        if args.turbulence_correction_with_pol :
+            new_x,new_y = correct_with_pol(spots["X_FP"][selection],spots["Y_FP"][selection],spots["X_FP_EXP"][selection],spots["Y_FP_EXP"][selection])
+        else :
+            new_x,new_y = correct(spots["X_FP"][selection],spots["Y_FP"][selection],spots["X_FP_EXP"][selection],spots["Y_FP_EXP"][selection])
         rms_before = np.sqrt(np.mean((spots["X_FP"][selection]-spots["X_FP_EXP"][selection])**2+(spots["Y_FP"][selection]-spots["Y_FP_EXP"][selection])**2))
         rms_after  = np.sqrt(np.mean((new_x-spots["X_FP_EXP"][selection])**2+(new_y-spots["Y_FP_EXP"][selection])**2))
         log.info("rms(measured-expected)={:5.4f}mm rms(corrected-expected)={:5.4f}mm ".format(rms_before,rms_after))

--- a/bin/desi_fvc_proc
+++ b/bin/desi_fvc_proc
@@ -72,9 +72,9 @@ parser.add_argument('--no-bias', action = 'store_true',
 parser.add_argument('--use-spotmatch', action = 'store_true',
                     help = 'use spotmatch instead of desimeter code for matching positioners and fiducials (requires the program match_positions installed and in the PATH)')
 parser.add_argument('--turbulence-correction', action = 'store_true',
-                    help = 'correct for turbulence assuming offsets between measured and expected coordinates are not spatially correlated. Only used in conjunction with option --expected-positions.')
+                    help = 'turbulence correction assuming offsets between measured and expected coordinates are not spatially correlated. Only used in conjunction with option --expected-positions.')
 parser.add_argument('--turbulence-correction-with-pol', action = 'store_true',
-                    help = 'correct for turbulence assuming offsets between measured and expected coordinates are not spatially correlated. Only used in conjunction with options --expected-positions, uses polynomial method instead of Gaussian processes ')
+                    help = 'turbulence correction using local polynomial fit instead of Gaussian processes.')
 
 args  = parser.parse_args()
 log   = get_logger()

--- a/py/desimeter/turbulence.py
+++ b/py/desimeter/turbulence.py
@@ -5,6 +5,133 @@ import scipy.linalg
 from desimeter.match_positioners import match
 from desimeter.log import get_logger
 
+import astropy.table as atpy
+import scipy.spatial
+import numpy as np
+
+# =================================================================
+# from Sergey : correction using local polynomial fit
+# =================================================================
+
+def getpoly(x, y, ndeg=2):
+    """
+    Get the 2D polynomial design matrix
+    """
+    N = len(x)
+    polys = np.zeros((((ndeg + 1) * (ndeg + 2)) // 2 - 1, N * 2))  # []
+    cnt = 0
+    for deg in range(1, ndeg + 1):
+        for j in range(deg + 1):
+            i1, i2 = j, deg - j
+            # notice the i1==0 i2==0 are there to prevent 0**(-1)
+            # these are dF/dx dF/dy of the polynomial
+            polys[cnt, :N] = i1 * x**(i1 - 1 + (i1 == 0)) * y**i2
+            polys[cnt, N:] = i2 * x**i1 * y**(i2 - 1 + (i2 == 0))
+            cnt += 1
+    return polys
+
+
+def predictor(curx, cury, curdx, curdy, tofit, ndeg=2, polys=None):
+    """
+    Fit the offsets by a polynomial f-n
+    return the model predictions and
+    the cross-validated norm
+    """
+    ncv = 3
+    if polys is None:
+        polys = getpoly(curx, cury, ndeg=ndeg)
+    else:
+        polys = polys[:((ndeg + 1) * (ndeg + 2)) // 2 - 1]
+    cvid = np.arange(2 * len(curx)) % ncv
+    norm = 0
+    dxy = np.concatenate((curdx, curdy))
+    tofit2 = np.concatenate((tofit, tofit))
+    for i in range(ncv):
+        cursub = tofit2 & (cvid != i)
+        cursub1 = tofit2 & (cvid == i)
+        xcoeff = scipy.linalg.basic.lstsq(polys[:, cursub].T,
+                                          dxy[cursub],
+                                          check_finite=False)[0]
+        xpred = np.dot(polys.T, xcoeff)[cursub1]
+        norm += np.sum((xpred - dxy[cursub1])**2)
+    xcoeff = scipy.linalg.basic.lstsq(polys[:, tofit2].T, dxy[tofit2])[0]
+    xpred, ypred = np.dot(polys.T, xcoeff)[~tofit2]
+    return xpred, ypred, norm, polys
+
+
+def correct_with_pol(x, y, x0, y0, win=50):
+    """
+    Parameters
+    ----------
+    x: ndarray
+        Measured x
+    y: ndarray
+        Measured y
+    x0: ndarray
+        Expected x
+    y0: ndarray
+        Expected y
+
+    Returns
+    -------
+    xy: tuple of ndarray
+        Tuple of corrected arrays
+
+    """
+    maxndeg = 4
+    # offsets wrt reference
+    dx = x - x0
+    dy = y - y0
+
+    X0 = np.array([x0, y0]).T
+    X = np.array([x, y]).T
+
+    T0 = scipy.spatial.cKDTree(X0)
+    N = len(x)
+
+    # predicted offset
+    dxpred = np.zeros(N)
+    dypred = np.zeros(N)
+    bestdegs = np.zeros(N)
+
+    for i in range(N):
+        # go over each point
+        # query the neighborhood
+        xids = T0.query_ball_point(X[i], win)
+        xids = np.array(xids)
+
+        curxcen, curycen = x[i], y[i]
+        curx = x[xids] - curxcen
+        cury = y[xids] - curycen
+        tofit = xids != i
+        curdx = dx[xids]
+        curdy = dy[xids]
+        bestnorm = 1e9
+        # try polynomials of different degrees
+        # selecting by cross-validate norm
+        polys = None
+        for ndeg in range(maxndeg, 0, -1):
+            xpred, ypred, norm, polys = predictor(curx,
+                                                  cury,
+                                                  curdx,
+                                                  curdy,
+                                                  tofit,
+                                                  ndeg=ndeg,
+                                                  polys=polys)
+            if norm < bestnorm:
+                bestnorm = norm
+                lastx, lasty = xpred, ypred
+                bestdeg = ndeg
+        dxpred[i] = lastx
+        dypred[i] = lasty
+        bestdegs[i] = bestdeg
+    return x - dxpred, y - dypred
+# ===============================================================
+
+
+# ===============================================================
+# From Eddie : correction using gaussian processes
+# ===============================================================
 
 def make_covar_gradwavefront(data, param, rq=False):
     """Make derivative-of-Gaussian covariance matrix for data given param.

--- a/py/desimeter/turbulence.py
+++ b/py/desimeter/turbulence.py
@@ -4,10 +4,7 @@ from scipy import optimize
 import scipy.linalg
 from desimeter.match_positioners import match
 from desimeter.log import get_logger
-
-import astropy.table as atpy
 import scipy.spatial
-import numpy as np
 
 # =================================================================
 # from Sergey : correction using local polynomial fit


### PR DESCRIPTION
 - Add Sergey's method as optional alternative to turbulence correction in `turbulence.py` (called with `correct_with_pol(...)`)
 - Add turbulence correction option to `desi_fvc_proc`.

Example with two FVC exposures on petal1
```
scp 'cori:/global/cfs/cdirs/desi/users/jguy/focalplane/petal1-at-lbl/turbulence/{fvc.20200904105027.fits,fvc.20200904105035.fits}' .
export DESIMETER_DATA=xxxxx/py/desimeter/data/lbl-petal1/
desi_fvc_proc -i fvc.20200904105035.fits -o fvc.20200904105035.csv
desi_fvc_proc -i fvc.20200904105027.fits -o fvc.20200904105027-corr.csv --expected fvc.20200904105035.csv  --turbulence-correction

INFO:desi_fvc_proc:259:<module>:rms(measured-expected)=0.0161mm rms(corrected-expected)=0.0029mm
```