### PR TITLE
bug fix when reading hexapod rotation in fits header

### DIFF
--- a/bin/desi_fit_guide_star_coordinates
+++ b/bin/desi_fit_guide_star_coordinates
@@ -8,6 +8,7 @@ import fitsio
 from desimeter.log import get_logger
 from desimeter.fieldmodel import FieldModel
 from desimeter.time import mjd2lst
+from desimeter.io import read_hexrot_deg
 
 parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                      description="""Fit guide star catalog to derive a field model (pointing, field rotation, scale)""")
@@ -18,7 +19,7 @@ parser.add_argument('-o','--outfile', type = str, default = None, required = Tru
 parser.add_argument('--fits-header', type = str, default = None, required = True,
                     help = 'path to file with fits header to read time and sky coordinates')
 parser.add_argument('--plot', action = 'store_true')
-                    
+
 args  = parser.parse_args()
 log   = get_logger()
 
@@ -32,11 +33,11 @@ if not "TARGTRA" in header :
         log.error("no TARGTRA in headers of HDU 0 or 1 of file {}".format(args.fits_header))
         sys.exit(12)
 
-        
+
 fm.ra  = header["TARGTRA"]
 fm.dec = header["TARGTDEC"]
 fm.expid = header["EXPID"]
-fm.hexrot_deg = float(header["FOCUS"][5])/3600.
+fm.hexrot_deg = read_hexrot_deg(header)
 
 fm.adc1 = header["ADC1PHI"]
 fm.adc2 = header["ADC2PHI"]
@@ -66,7 +67,7 @@ if args.plot :
     # re-read the model to also test the I/O
     with open(args.outfile) as file :
         fm = FieldModel.fromjson(file.read())
-    
+
     xfp,yfp = fm.all_gfa2fp(xgfa,ygfa,pet)
     ra2,dec2=fm.fp2radec(xfp,yfp)
 
@@ -79,7 +80,7 @@ if args.plot :
     dr2=dx**2+dy**2
     rms=np.sqrt(np.mean(dr2))
     print("rms (GAIA RA,Dec - Measurement) = {:3.2f} arcsec".format(rms*3600.))
-    
+
     plt.figure("sky")
     plt.plot(-ra,dec,"o",label="GAIA")
     plt.plot(-ra2,dec2,"x",label="Measurements")
@@ -87,4 +88,3 @@ if args.plot :
     plt.ylabel("Dec (deg)")
     plt.legend()
     plt.show()
-    

--- a/bin/desi_predict_fieldrot
+++ b/bin/desi_predict_fieldrot
@@ -8,6 +8,7 @@ import fitsio
 from desimeter.log import get_logger
 from desimeter.fieldmodel import fieldrot,dfieldrotdt
 from desimeter.time import mjd2lst
+from desimeter.io import read_hexrot_deg
 
 parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                      description="""Predict the field rotation. Need an input fits header or ra,dec,lst,mjd or ra,dec,ha,mjd or ra,dec,mjd (with decimal mjd to guess the lst)""")
@@ -19,7 +20,7 @@ parser.add_argument('--dec', type = float, default = None, required = False,
 parser.add_argument('--lst', type = float, default = None, required = False,
                     help = 'LST=HA+RA in deg')
 parser.add_argument('--ha', type = float, default = None, required = False,
-                    help = 'HA=LST-RA in deg')		    
+                    help = 'HA=LST-RA in deg')
 parser.add_argument('--mjd', type = float, default = None, required = False,
                     help = 'MJD in days')
 parser.add_argument('--hexrot-arcsec', type = float, default = 0., required = False,
@@ -45,7 +46,7 @@ if args.fits_header is not None :
         if not "TARGTRA" in header :
             log.error("no TARGTRA in headers of HDU 0 or 1 of file {}".format(args.fits_header))
             sys.exit(12)
-    
+
     ra  = header["TARGTRA"]
     dec = header["TARGTDEC"]
     mjd = header["MJD-OBS"]
@@ -59,8 +60,8 @@ if args.fits_header is not None :
         lst = mjd2lst(mjd)
 
     if "HEXPOS" in header :
-         hexrot_deg = float(header["FOCUS"][5])/3600.
-        
+         hexrot_deg = read_hexrot_deg(header)
+
 else :
     ra  = args.ra
     dec = args.dec
@@ -73,13 +74,10 @@ else :
         lst = mjd2lst(mjd)
     if args.hexrot_arcsec != 0 :
         hexrot_deg = args.hexrot_arcsec/3600.
-    
+
 if ra is None or dec is None or mjd is None or lst is None :
     print("missing argument(s), try --help")
     sys.exit(12)
 
 print("FIELDROT    = {:4.3f} deg".format( fieldrot(ra=ra,dec=dec,lst_deg=lst,mjd=mjd,hexrot_deg=hexrot_deg)))
 print("DFIELDROTDT = {:4.3f} arcsec/min".format( dfieldrotdt(ra=ra,dec=dec,lst_deg=lst,mjd=mjd)))
-
-
-        

--- a/py/desimeter/io.py
+++ b/py/desimeter/io.py
@@ -4,6 +4,34 @@ from astropy.table import Table
 import yaml
 from desimeter.log import get_logger
 
+def read_hexrot_deg(header) :
+    '''Extract from header the hexapod rotation angle (works with both fitsio version 0.9 and 1.1)
+
+    Args:
+        header : fits header or dictionary
+
+    Returns:
+       hexapod rotation angle in degree
+    '''
+    log = get_logger()
+
+    focus_params = header["FOCUS"]
+    if isinstance(focus_params,str) :
+        focus_params = focus_params.split(",")
+    elif not isinstance(focus_params,tuple) :
+        message="header['FOCUS']={} is not a str nor a tuple".format(focus_params)
+        log.error(message)
+        raise ValueError(message)
+    if len(focus_params) != 6 :
+        message="I expected 6 coefficient in header['FOCUS']={}".format(focus_params)
+        log.error(message)
+        raise ValueError(message)
+    hexrot_deg = float(focus_params[5])/3600.
+    log.debug("Use hexrot_deg={} from FOCUS={}".format(hexrot_deg,header["FOCUS"]))
+    return hexrot_deg
+
+
+
 def desimeter_data_dir():
     '''
     Returns desimeter data dir


### PR DESCRIPTION
Bug fix when reading hexapod rotation in fits header of guide image arising with change of fitsio version from 0.9.11 to 1.1.2.
(Now works with both versions and hopefully others!)
