### PR TITLE
let fetched posmovedb rows have same timestamp as calib

### DIFF
--- a/bin/get_posmoves
+++ b/bin/get_posmoves
@@ -121,7 +121,7 @@ for petalid in petalids :
                 posmoves[k]=list()
 
             for t in tstamp_posmovedb :
-                j=np.where(tstamp_calib<t)[0][-1]
+                j=np.where(tstamp_calib<=t)[0][-1]
                 for k1,k2 in zip(new_keys,calib.keys()) :
                     posmoves[k1].append(calib[k2][j])
 


### PR DESCRIPTION
example call
```
get_posmoves --host beyonce.lbl.gov --port 5432 --password <pw> --petal-ids 0 -o petal1_alltime -c -t
```
Try it with / without this fix and you will see why i did it