### PR TITLE
Clear tmp before analyze bright

### DIFF
--- a/bin/analyze_bright_image
+++ b/bin/analyze_bright_image
@@ -42,7 +42,7 @@ if args.phi_arm_angle_table is not None :
     spots = Table.read(args.phi_arm_angle_table)
 else :
     print("Process standard back illuminated FVC image {}".format(args.back_illuminated))
-    spots = process_fvc(args.back_illuminated)
+    spots = process_fvc(args.back_illuminated, overwrite=True)
     template_filename = os.path.join(desimeter_data_dir(),"fiber_arm_outline.fits")
     detect_phi_arms(spots,args.front_illuminated,template_filename,args.ang_step,args.nproc)
 

--- a/bin/analyze_bright_image
+++ b/bin/analyze_bright_image
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 
 import argparse
-import sys,os
+import os
 import numpy as np
-import multiprocessing
 import matplotlib.pyplot as plt
 import fitsio
 

--- a/py/desimeter/processfvc.py
+++ b/py/desimeter/processfvc.py
@@ -3,15 +3,24 @@ import sys
 import subprocess
 from astropy.table import Table
 
-def process_fvc(filename) :
+def process_fvc(filename, overwrite=False):
+    '''Calls desi_fvc_proc on the input file.
+    
+    INPUTS:  filename ... fits file (can also be csv, in which case desi_fvc_proc is skipped)
+             overwrite ... if a processed table of the same basename already exists in /tmp,
+                           reprocess and overwrite it with new table. (default behavior is
+                           to use the already-existing table)
+                           
+    OUTPUT:  astropy table
+    '''
     if filename.find(".csv")>0 :
         # already a coordinates table
         return Table.read(filename)
     if filename.find(".fits")<0 :
         print("don't know what to do with",filename)
         sys.exit(12)
-    outfilename=os.path.join("/tmp",os.path.basename(filename.replace(".fits",".csv")))
-    if os.path.isfile(outfilename) :
+    outfilename = get_outfilename(filename)
+    if os.path.isfile(outfilename) and not overwrite:
         print("using previously processed {}".format(outfilename))
     else :
         cmd="desi_fvc_proc -i {} -o {}".format(filename,outfilename)
@@ -21,3 +30,10 @@ def process_fvc(filename) :
             print("we got an error code = {}".format(errcode))
             sys.exit(errcode)
     return Table.read(outfilename)
+
+def get_outfilename(path_to_fits):
+    out_dir = '/tmp'
+    csv_name= path_to_fits.replace(".fits",".csv")
+    basename = os.path.basename(csv_name)
+    out = os.path.join(out_dir, basename)
+    return out

--- a/py/desimeter/processfvc.py
+++ b/py/desimeter/processfvc.py
@@ -5,12 +5,12 @@ from astropy.table import Table
 
 def process_fvc(filename, overwrite=False):
     '''Calls desi_fvc_proc on the input file.
-    
+
     INPUTS:  filename ... fits file (can also be csv, in which case desi_fvc_proc is skipped)
              overwrite ... if a processed table of the same basename already exists in /tmp,
                            reprocess and overwrite it with new table. (default behavior is
                            to use the already-existing table)
-                           
+
     OUTPUT:  astropy table
     '''
     if filename.find(".csv")>0 :


### PR DESCRIPTION
If you name an input back illuminated image the same name as previously, then process_fvc would skip the new file and just use the old csv file in /tmp. I added an option to process_fvc where it will process the image and write a new table. The option is default off, so no other implications on existing code.