### PR TITLE
Let desimeter routines make directories for output if needed.

### DIFF
--- a/bin/desi_fit_guide_star_coordinates
+++ b/bin/desi_fit_guide_star_coordinates
@@ -19,6 +19,8 @@ parser.add_argument('-o','--outfile', type = str, default = None, required = Tru
 parser.add_argument('--fits-header', type = str, default = None, required = True,
                     help = 'path to file with fits header to read time and sky coordinates')
 parser.add_argument('--plot', action = 'store_true')
+parser.add_argument('--make-directory', action='store_true',
+                    help='Make directory for output if needed.')
 
 args  = parser.parse_args()
 log   = get_logger()
@@ -53,6 +55,12 @@ fm.lst  = mjd2lst(fm.mjd) # mjd is set when reading catalog or above
 fm.fit_tancorr(catalog)
 
 # save it
+if args.make_directory:
+    directory, fn = os.path.split(args.outfile)
+    if directory != '':
+        if not os.path.exists(directory):
+            os.makedirs(directory)
+
 with open(args.outfile, 'w') as file:
     file.write(fm.tojson())
 print("wrote",args.outfile)

--- a/bin/desi_fvc_proc
+++ b/bin/desi_fvc_proc
@@ -75,6 +75,8 @@ parser.add_argument('--turbulence-correction', action = 'store_true',
                     help = 'turbulence correction assuming offsets between measured and expected coordinates are not spatially correlated. Only used in conjunction with option --expected-positions.')
 parser.add_argument('--turbulence-correction-with-pol', action = 'store_true',
                     help = 'turbulence correction using local polynomial fit instead of Gaussian processes.')
+parser.add_argument('--make-directory', action='store_true',
+                    help='Make directory for output if needed.')
 
 args  = parser.parse_args()
 log   = get_logger()
@@ -141,6 +143,17 @@ else :
     log.info("sorry, I don't know what to do with input file {} because not .fits nor .csv".format(filename))
     sys.exit(12)
 
+
+if args.make_directory:
+    directory, fn = os.path.split(args.outfile)
+    if directory != '':
+        if not os.path.exists(directory):
+            os.makedirs(directory)
+    if args.output_transform is not None:
+        directory, fn = os.path.split(args.outfile)
+        if directory != '':
+            if not os.path.exists(directory):
+                os.makedirs(directory)
 
 for seqid,spots in enumerate(spots_list) :
 


### PR DESCRIPTION
This PR adds make-directory arguments to desi_fvc_proc and desi_fit_guide_star_coordinates.  If set, output files from these two routines may be paths including directories which may not yet exist.  Should these directories not yet exist, they will be created.

This is convenient if one is making a bunch of output files separated following the usual DESI YYYYMMDD/EXPID/output-EXPID.csv convention, and one does not want to preemptively make all of the YYYYMMDD/EXPID directories.  