### PR TITLE
remove parsing 'freeze' in log_note string from inclusion as "FROZEN"

### DIFF
--- a/bin/analyze_pos_performance
+++ b/bin/analyze_pos_performance
@@ -494,9 +494,8 @@ def identify_avoidances(table):
                 separator = separator_options[0]
                 avoidances = avoidances.split(separator)
                 counts[i] += len(avoidances)
-                frozen[i] = any('freeze' in string for string in avoidances)
         if 'FROZEN' in new['FLAG_STRINGS'][i]:
-            frozen[i] = True  # redundant check, in case of discrepancy in log note parsing
+            frozen[i] = True
     new['NUM_COLLISION_AVOIDANCES'] = counts
     new['FROZEN'] = frozen
     return new


### PR DESCRIPTION
This prevents false positives, in cases of intermediate "freeze" during a given move table, but which eventually gets resolved at a later point by the anticollision code.