### PR TITLE
Make new fvc2fp parameters optional.

### DIFF
--- a/py/desimeter/transform/fvc2fp.py
+++ b/py/desimeter/transform/fvc2fp.py
@@ -88,10 +88,12 @@ class FVC2FP(object):
         params['offset_y'] = self.offset_y
         params['zbpolids'] = [int(polid) for polid in self.zbpolids]
         params['zbcoeffs'] = list(self.zbcoeffs)
-        params['meandistance'] = self.meandistance
-        params['mediandistance'] = self.mediandistance
-        params['rmsdistance'] = self.rmsdistance
-        params['nmatch'] = self.nmatch
+        optional_fields = ['meandistance', 'mediandistance', 'rmsdistance',
+                           'nmatch']
+        for field in optional_fields:
+            val = getattr(self, field, None)
+            if val is not None:
+                params[field] = val
         return json.dumps(params)
 
     def __str__(self) :


### PR DESCRIPTION
This intends to address
https://github.com/desihub/desimeter/issues/162
making the additional fit information parameters in the fvc2fp data structure optional.  An alternative solution would have been to update the init-fvc2fp.json file, but making these parameters optional makes this less likely to occur again in the future.