### PR TITLE
prepare_posparams update

### DIFF
--- a/bin/prepare_posparams_for_instr
+++ b/bin/prepare_posparams_for_instr
@@ -578,7 +578,7 @@ for key, commit_key in commit_keys.items():
     
     # 2020-12-10 [JHS] Do *NOT* commit anything for devices we are setting as nonfunctional.
     # Because in practice these are cases where we don't trust the calibration.
-    new_table[commit_key] |= new_table[disable_key]
+    new_table[commit_key] &= new_table[disable_key] == False
 
     delayed_log_notes += [f'{commit_key} {method} to {set_val} for all positioners']
     will_commit = new_table[commit_key]

--- a/bin/prepare_posparams_for_instr
+++ b/bin/prepare_posparams_for_instr
@@ -196,16 +196,29 @@ def _eliminate_rows(table, elim, rationale):
     logger.warning(f'{n_elim_rows} of {n_rows} rows have {rationale}. These' +
                    ' rows will be excluded from the output table. This eliminates' +
                    f' the following {n_elim_posids} positioners from the table:' +
-                   f' {sorted(posids_eliminated)}')
+                   f' {sorted(posids_eliminated)}' +
+                   f'\nThis leaves {len(posids_remaining)} of {len(all_posids)} positioners remaining.')
     output = table.copy()
     output.remove_rows(elim_bool)
     return output
 
+# delete any rows for which a required value is masked
+required_keys = {'POS_ID', 'FLAGS', 'DEVICE_LOC', 'NUM_POINTS', 'DATA_END_DATE',
+                 'FIT_ERROR_STATIC', 'NUM_POINTS_IN_FIT_STATIC',}
+required_keys |= set(fitter.static_keys)
+if uargs.allow_scale:
+    required_keys |= {'FIT_ERROR_DYNAMIC', 'NUM_POINTS_IN_FIT_DYNAMIC'}
+mask_table = new_table.mask
+masked_list = mask_table['POS_ID']
+for key in required_keys:
+    masked_list |= mask_table[key]
+new_table = _eliminate_rows(new_table, masked_list, 'missing required value(s)')
+
+# check functions
 def check_flags(table):
     '''Inspects FLAGS field of fit results.
-    
-    Internal details: Returns a copy of table.
-    '''
+    '''    
+    # Internal details: Returns a copy of table.
     new = table.copy()
     for flag in movemask.names():
         fail_list = [movemask[flag] & value for value in new['FLAGS']]
@@ -219,9 +232,8 @@ def check_static_fit_bounds(table, tighten_factor):
     with numeric errors. It tightens the acceptable bounds by a fraction. E.g.,
     for a range [0.0, 2.0], a tighten_factor of 0.1 would use range [0.2, 1.8] in
     the filter.
-    
-    Internal details: Returns a copy of table.
-    '''
+    '''    
+    # Internal details: Returns a copy of table.
     below_key = 'below min'
     above_key = 'above max'
     new = table.copy()
@@ -242,9 +254,8 @@ def check_xy_offsets(table, tol):
     '''Checks reasonableness of OFFSET_X and OFFSET_Y w.r.t. metrology values.
     Argument 'tol' is a value in mm. Rows outside this tolerance will be
     eliminated from the output.
-    
-    Internal details: Returns a copy of table.
     '''
+    # Internal details: Returns a copy of table.
     new = table.copy()
     expected_centers = desimeter.io.load_nominal_positioner_locations()
     delete_idxs = set()
@@ -268,9 +279,8 @@ def check_arm_lengths(table, tol):
     '''Checks closeness of LENGTH_R1 and LENGTH_R2 to their nominal values.
     Argument 'tol' is a value in mm. Rows outside this tolerance will be
     eliminated from the output.
-    
-    Internal details: Returns a copy of table.
     '''
+    # Internal details: Returns a copy of table.
     new = table.copy()
     expected_lengths = {key: fitter.default_values[key] for key in ['LENGTH_R1', 'LENGTH_R2']}
     delete_idxs = set()
@@ -287,21 +297,21 @@ def check_arm_lengths(table, tol):
     return new
 
 def check_fit_error(table, tol, key, set_enabling):
-    '''Checks overall goodness of fit for.
-        tol ... value in rms mm
-        key ... 'STATIC' or 'DYNAMIC'
-        set_enabling ... True  --> usual behavior of eliminating rows if not within tol
-                         False --> keep row and mark DEVICE_CLASSIFIED_NONFUNCTIONAL to
-                                   True or False depending on whether threshold was met
-    
-    Internal details: Returns a copy of table.
+    '''Checks overall goodness of fit for. Argument 'tol' is max value in rms mm.
     '''
+    # Internal details:
+    #     Returns a copy of table.
+    #     key ... 'STATIC' or 'DYNAMIC'
+    #     set_enabling ... True  --> usual behavior of eliminating rows if not within tol
+    #                      False --> keep row and mark DEVICE_CLASSIFIED_NONFUNCTIONAL to
+    #                                True or False depending on whether threshold was met
     new = table.copy()
     fit_err_key = 'FIT_ERROR_STATIC' if 'STATIC' in key else 'FIT_ERROR_DYNAMIC'
     fit_errs = new[fit_err_key]
     failures = fit_errs > tol
     if set_enabling:
         new[disable_key] = failures
+        will_disable = set(new['POS_ID'][new[disable_key]])
         for row in new:
             action = f'{disable_key}={row[disable_key]} because'
             sign = '>' if row[disable_key] else '<='
@@ -312,27 +322,33 @@ def check_fit_error(table, tol, key, set_enabling):
         for i in np.flatnonzero(failures):
             logger.warning(f'Row for {new["POS_ID"][i]} removed due to {fit_err_key}={fit_errs[i]} > tol={tol}')
         new.remove_rows(failures)
+    if set_enabling:
+        logger.warning(f'{len(will_disable)} positioners will have {disable_key} --> True')
     return new
 
 def check_num_outliers(table, tol, key):
-    '''Checks number of outliers that were discarded during the fit.
-        tol ... integer >= 0
-        key ... 'STATIC' or 'DYNAMIC'
-    
-    Internal details: Returns a copy of table.
+    '''Checks number of outliers that were discarded during the fit. Argument 'tol'
+    is an integer >= 0, giving the max number of outliers allowed.
     '''
+    # Internal details:
+    #     Returns a copy of table.
+    #     key ... 'STATIC' or 'DYNAMIC'
     assert key in ['STATIC', 'DYNAMIC']
-    assert isinstance(tol, int)
+    assert isinstance(tol, (int, float))
     assert 0 <= tol
-    
     new = table.copy()
-    num_outliers_key = f'NUM_POINTS_IN_{key}'
+    num_points_in_fit_key = f'NUM_POINTS_IN_FIT_{key}'
+    num_outliers_key = f'NUM_OUTLIERS_{key}'
+    new[num_outliers_key] = new['NUM_POINTS'] - new[num_points_in_fit_key]
+    exceeds_tol = new[num_outliers_key] > tol
+    new = _eliminate_rows(new, exceeds_tol, f'number of outliers > {tol}')
+    return new
 
 def check_recent_rehome(table):
     '''Searches for "recent rehome" criterion. This indicates that OFFSET_T and
     OFFSET_P are ok for use on instrument.
-    
-    Internal details: Returns a copy of table.'''
+    '''
+    # Internal details: Returns a copy of table.
     # As of 2020-06-15, not implemented. The assumption is that fit_posparams
     # output file contains only good OFFSET_T, OFFSET_P, generated from an
     # assumed RECENT_REHOME==True data set. Hopefully in the future we can
@@ -342,8 +358,8 @@ def check_recent_rehome(table):
 def check_uniqueness(table):
     '''Searches for multiple rows with same POS_ID, and asks user to resolve
     any conflicts.
-    
-    Internal details: Returns a copy of table.'''
+    '''
+    # Internal details: Returns a copy of table.
     unique_posids = set(table['POS_ID'])
     new = table.copy()
     def get_row_idxs(table, posid):
@@ -398,7 +414,8 @@ class Check(object):
     
     @property
     def doc(self):
-        return f'{self.name}:\n{self.func.__doc__}'
+        wrapped = " ".join(self.func.__doc__.split())
+        return f'{self.name}:\n{wrapped}'
     
     def run(self, table):
         '''Performs the check function on astropy table of parameters data.'''
@@ -410,7 +427,7 @@ class Check(object):
         if n_deleted:
             done_note += f'{n_deleted} rows deleted'
         else:
-            done_note += 'All rows ok'
+            done_note += 'No rows deleted'
         logger.info(f'{done_note}, {len(output)} remaining')
         return output
     
@@ -460,9 +477,12 @@ if uargs.set_enabling:
     yesnohelp(msg, yes=True, no=False, help_=False, exit_=True)
 
 # set up and run checks
-checks = [Check(check_fit_error, tol=fit_err_tol, key='STATIC', set_enabling=uargs.set_enabling)]
+fits_to_check = ['STATIC']
 if uargs.allow_scale:
-    checks += [Check(check_fit_error, tol=fit_err_tol, key='DYNAMIC', set_enabling=uargs.set_enabling)]
+    fits_to_check += ['DYNAMIC']
+for fit_key in fits_to_check:
+    checks = [Check(check_num_outliers, tol=2, key=fit_key)]
+    checks += [Check(check_fit_error, tol=fit_err_tol, key=fit_key, set_enabling=uargs.set_enabling)]
 checks += [Check(check_flags)]
 checks += [Check(check_static_fit_bounds, tighten_factor=0.001)]
 checks += [Check(check_xy_offsets, tol=0.5)]

--- a/bin/prepare_posparams_for_instr
+++ b/bin/prepare_posparams_for_instr
@@ -187,6 +187,15 @@ def join_notes(*args):
     strings = (str(x) for x in args if x != '')
     return separator.join(strings)
 
+def _current_total_alt_str(table):
+    '''String saying total number of rows either deleted or marked so far.'''
+    s = f'Current total {elim_action_str} = '
+    if uargs.set_enabling:
+        s += str(len(np.where(table[disable_key])[0]))
+    else:
+        s += str(len(input_table) - len(table))
+    return s
+
 def _eliminate_rows(table, elim, rationale):
     '''Logs messages and returns a copy of table, with rows identified by elim
     either deleted from it or marked DEVICE_CLASSIFIED_NONFUNCTIONAL.
@@ -211,18 +220,15 @@ def _eliminate_rows(table, elim, rationale):
     msg = f'{n_elim_rows} of {n_rows} rows have {rationale}. These rows will be {elim_action_str} ' + \
           f'from the output table. Affected positioners are:\n{sorted(posids_eliminated)}' + \
           f'\nTotal {elim_action_str} = {n_elim_posids}' + \
-          f'\nNot {elim_action_str} = {len(posids_remaining)}' + \
-          f'\nCurrent total {elim_action_str} = '
+          f'\nNot {elim_action_str} = {len(posids_remaining)}'
     output = table.copy()    
     if uargs.set_enabling:
         output[disable_key] |= elim_bool
         existing = output[disable_rationale_key].tolist()
         output[disable_rationale_key] = [join_notes(existing[i], rationale) if elim_bool else existing[i] for i in range(len(output))]
-        msg += str(len(np.where(output[disable_rationale_key])[0]))
     else:
         output.remove_rows(elim_bool)
-        msg += str(len(input_table) - len(output))
-    logger.warning(msg)
+    logger.warning(f'{msg}\n{_current_total_alt_str(output)}')
     return output
 
 # eliminate any rows for which a required value is masked
@@ -330,6 +336,11 @@ def check_fit_error(table, tol, key):
     #     set_enabling ... True  --> usual behavior of eliminating rows if not within tol
     #                      False --> keep row and mark DEVICE_CLASSIFIED_NONFUNCTIONAL to
     #                                True or False depending on whether threshold was met
+    #
+    # 2020-12-10 [JHS] This function has some historical special handling for marking /
+    # eliminating rows. Better would be to fold into _eliminate_rows like all the other
+    # check functions. However there was some special line-by-line rationale string handling
+    # I had in there which I didn't want to disturb at this time.
     new = table.copy()
     fit_err_key = 'FIT_ERROR_STATIC' if 'STATIC' in key else 'FIT_ERROR_DYNAMIC'
     fit_errs = new[fit_err_key]
@@ -369,7 +380,7 @@ def check_num_outliers(table, tol, key):
     num_outliers_key = f'NUM_OUTLIERS_EXCLUDED_{key}'
     new[num_outliers_key] = new['NUM_POINTS'] - new[num_points_in_fit_key]
     exceeds_tol = new[num_outliers_key] > tol
-    new = _eliminate_rows(new, exceeds_tol, f'number of outliers > {tol}')
+    new = _eliminate_rows(new, exceeds_tol, f'number of outliers > tol={tol}')
     return new
 
 def check_recent_rehome(table):
@@ -516,7 +527,7 @@ for fit_key in fits_to_check:
 checks += [Check(check_flags)]
 checks += [Check(check_static_fit_bounds, tighten_factor=0.001)]
 checks += [Check(check_xy_offsets, tol=0.5)]
-checks += [Check(check_arm_lengths, tol=0.4)]
+checks += [Check(check_arm_lengths, tol=0.5)]
 #checks += [Check(check_recent_rehome)]
 checks += [Check(check_uniqueness)]
 for check in checks:
@@ -554,16 +565,20 @@ for key, commit_key in commit_keys.items():
         while True:
             answer = yesnohelp(f'Shall we commit {key} to online database?')
             if answer == 'help':
-                logger.info(f'This will set the field {commit_key} to True or False, for' +
-                            ' all remaining positioners in the parameters table (after the' +
-                            ' checks which were just completed). It does not send anything' +
-                            ' to the database at this time. We are just constructing an' +
-                            ' input file right now. Later on, when we feed the input file' +
-                            f' to pecs/set_calibrations.py, *then* the {commit_key} field will' +
-                            ' tell that script whether or not to actually store the associated' +
-                            ' value to the online DB. If you have any doubts about validity of' +
-                            ' the data, reply "no" and discuss with the focal plane team.' +
-                            ' Devs J.Silber, K.Fanning, or J.Guy should be able to assist.')
+                msg = f'This will set the field {commit_key} to True or False, for ' + \
+                      ' all remaining positioners in the parameters table'
+                if uargs.set_enabling:
+                    msg += '. All {elim_action_str} positioners will have {commit_key} forced to False.'
+                else:
+                    msg += ' (after the checks which were just completed).'
+                msg += ' We are not sending anything to the database at this time. We are only' + \
+                       ' constructing an input file right now. Later on, when we feed the input' + \
+                       f' file to pecs/set_calibrations.py, *then* the {commit_key} field will' + \
+                       ' tell that script whether or not to actually store the associated' + \
+                       ' value to the online DB. If you have any doubts about validity of' + \
+                       ' the data, reply "no" and discuss with the focal plane team.' + \
+                       ' Devs J.Silber, K.Fanning, or J.Guy should be able to assist.'
+                logger.info(msg)
             elif answer == 'no':
                 set_val = False
                 break
@@ -572,6 +587,11 @@ for key, commit_key in commit_keys.items():
                 break
         method = 'set by user'
     new_table[commit_key] = set_val
+    
+    # 2020-12-10 [JHS] Do *NOT* commit anything for devices we are setting as nonfunctional.
+    # Because in practice these are cases where we don't trust the calibration.
+    new_table[commit_key] |= new_table[disable_key]
+
     delayed_log_notes += [f'{commit_key} {method} to {set_val} for all positioners']
     will_commit = new_table[commit_key]
     posids_to_commit |= set(new_table['POS_ID'][will_commit])
@@ -586,7 +606,7 @@ if uargs.set_enabling:
     for i in range(len(new_table)):
         row = new_table[i]
         if row[disable_rationale_key]:
-            action = f'{disable_key}={row[disable_key]} because '
+            action = f'{disable_key}={row[disable_key]} because: '
             rationales[i] = action + rationales[i]
     new_table[disable_rationale_key] = rationales
 

--- a/bin/prepare_posparams_for_instr
+++ b/bin/prepare_posparams_for_instr
@@ -11,6 +11,24 @@ disable_key = 'DEVICE_CLASSIFIED_NONFUNCTIONAL'
 disable_rationale_key = 'ENABLE_DISABLE_RATIONALE'
 commit_prefix = 'COMMIT_'
 
+set_enabling_docstr = f'''
+    1. When set-enabling == False (default):
+    ----------------------------------------
+    Positioners which fail the fit error threshold check will simply be removed
+    from the output file. Thus no changes will be pushed to DB for these. This is
+    the appropriate behavior, for example, if the fit fails due to a math error,
+    noise, or bad measurement data.
+    
+    2. When set-enabling == True (command-line option '-e'):
+    --------------------------------------------------------
+    Output file will include a column {disable_key}. This will
+    contain True/False values reflecting pass/fail of the fit error threshold test.
+    The script set_calibrations.py can subsequently batch enable or disable positioners
+    accordingly. (Note: Like all the other parameters, you will *additionally* be
+    offered a redundant option to set {commit_prefix + disable_key} to False,
+    which *prevents* any enable/disable action from being actually performed.)
+'''
+
 __doc__ = f'''
 Inspects paramfits csv table and prepares a version of the table which is
 ready for operational use on the focal plane.
@@ -28,19 +46,8 @@ As of this writing (2020-06-12) the typical sequence is:
     
 See DESI-5732 for data model and procedures.
 
-Important note regarding '--set-enabling' ('-s') argument:
-    
-    The default behavior is that positioners which fail the fit error threshold
-    check will simply be removed from the output file. Thus no changes will be
-    pushed to DB for these. This is the appropriate behavior, for example, if
-    the fit fails due to a math error, noise, or bad measurement data.
-    
-    If you do '--set-enabling', then the behavior is different. The output file
-    will include a column {disable_key}. It will have True/False values reflecting
-    pass/fail of the fit error threshold test. Then set_calibrations.py can batch
-    enable or disable positioners accordingly. Like all the other parameters, you
-    will still be offered a redundant option to set {commit_prefix + disable_key}
-    to False, which would prevent any enable/disable from being actually performed.
+Important note regarding '--set-enabling' ('-e') argument:
+{set_enabling_docstr}
 '''
 
 force_no_scale = True
@@ -130,18 +137,29 @@ def input2(message):
 
 blank_responses = {'', '(no entry)'}
 
-def yesnohelp(message):
+def yesnohelp(message, yes=True, no=True, help_=True, exit_=True):
     '''Wrapper for user input which cleans up human-entered values and returns
-    a string of exactly 'yes', 'no', or 'help'.
+    a string of exactly 'yes', 'no', or 'help'. Also can give user option to
+    exit the program.
+    
+    Boolean args allow you to turn off options for the user.
     '''
-    answer =  input2(f'{message} (y/n/help/exit)')
-    if answer.lower() in {'h', 'help', 'doc', 'man'}:
+    assert yes or no or help_ or exit_, 'need at least one user option'
+    suffix_parts = ['y' if yes else None,
+                    'n' if no else None,
+                    'help' if help_ else None,
+                    'exit' if exit_ else None,
+                    ]
+    suffix_parts = [s for s in suffix_parts if s]
+    suffix = '/'.join(suffix_parts)
+    answer =  input2(f'{message} ({suffix})')
+    if help_ and answer.lower() in {'h', 'help', 'doc', 'man'}:
         return 'help'
-    if answer.lower() in {'n', 'no', 'false'}:
+    if no and answer.lower() in {'n', 'no', 'false'}:
         return 'no'
-    if answer.lower() in {'y', 'yes', 'true'}:
+    if yes and answer.lower() in {'y', 'yes', 'true'}:
         return 'yes'
-    if answer.lower() in {'exit'}:
+    if exit_ and answer.lower() in {'exit'}:
         logger.info('Exiting at user request.')
         sys.exit(0)
     return yesnohelp(message)
@@ -424,15 +442,9 @@ class Check(object):
 # additional user help for cases where we are possibly disabling positioners
 fit_err_tol = 0.03
 if uargs.set_enabling:
-    pos_perform_tol = 0.1
-    input2('Option "set-enabling" is on. In this mode, rather than determining mathematical ' +
-           'quality of best fit parameters (for which we typically start with a fit error tol ' +
-           f'value like {fit_err_tol} mm), we are more interested here in determining ' + 
-           f'positioner performance. For this, we use tolerance = {pos_perform_tol} mm. The ' +
-           'recommendation is that you *not* change this value, unless it has been discussed ' +
-           'among the focal plane experts team and agreed to. Press enter to acknowledge:')
-    fit_err_tol = pos_perform_tol
-    logger.info(f'fit_err_tol updated to {fit_err_tol} mm')
+    msg = f'\n\nOption "set-enabling" is on. Details:\n{set_enabling_docstr}\n' + \
+          'Please confirm this mode (see paragraph 2 above) is what you want, or exit: '
+    yesnohelp(msg, yes=True, no=False, help_=False, exit_=True)
 
 # set up and run checks
 checks = [Check(check_fit_error, tol=fit_err_tol, key='STATIC', set_enabling=uargs.set_enabling)]

--- a/bin/prepare_posparams_for_instr
+++ b/bin/prepare_posparams_for_instr
@@ -173,14 +173,28 @@ def str2float(s):
     except:
         return None
 
-def _eliminate_rows(table, elim, rationale):
+def join_notes(*args):
+    '''Concatenate items into a "note" string with standard format. A list or
+    tuple arg is treated as a single "item". So for example if you want the
+    subelements of a list "joined", then argue it expanded, like *mylist
+    '''
+    separator = '; '
+    if len(args) == 0:
+        return ''
+    elif len(args) == 1:
+        return str(args[0])
+    strings = (str(x) for x in args if x != '')
+    return separator.join(strings)
+
+def _eliminate_rows(table, elim, rationale, mark=False):
     '''Logs messages and returns a copy of table, with rows identified by elim
-    deleted from it.
+    either deleted from it or marked DEVICE_CLASSIFIED_NONFUNCTIONAL.
     
         table ... astropy table
         elim ... list of booleans saying whether to eliminate that row
                  must be same length as table
-        rationale ... string message to include in log output message
+        rationale ... string message to include in log output message, or a list
+                      of strings of same length as table
     '''
     assert len(table) == len(elim), f'len(table)={len(table)} != len(elim)={len(elim)}'
     if not(any(elim)):
@@ -193,13 +207,27 @@ def _eliminate_rows(table, elim, rationale):
     n_rows = len(table)
     n_elim_rows = len(np.flatnonzero(elim_bool))  # flatnonzero is like argwhere but better
     n_elim_posids = len(posids_eliminated)
-    logger.warning(f'{n_elim_rows} of {n_rows} rows have {rationale}. These' +
-                   ' rows will be excluded from the output table. This eliminates' +
-                   f' the following {n_elim_posids} positioners from the table:' +
-                   f' {sorted(posids_eliminated)}' +
+    action = 'marked' if mark else 'excluded'
+    rationale_msg = f'{n_elim_rows} of {n_rows} rows'
+    if isinstance(rationale, str):
+        rationale_msg += f' have {rationale}'
+        rationale_list = [rationale if e else '' for e in elim_bool]
+    else:
+        rationale_list = list(rationale)
+        printable_rationale = '\n'.join(rationale_list)
+        rationale_msg += f' {action} due to:\n{printable_rationale}'
+    logger.warning(rationale_msg)
+    logger.warning('These rows will be {action} from the output table. Affected positioners are:' +
+                   f'\n{sorted(posids_eliminated)}\nTotal {action} = {n_elim_posids}' +
                    f'\nThis leaves {len(posids_remaining)} of {len(all_posids)} positioners remaining.')
-    output = table.copy()
-    output.remove_rows(elim_bool)
+    output = table.copy()    
+    if mark:
+        assert len()
+        output[disable_key] |= elim_bool
+        existing = output[disable_rationale_key].tolist()
+        output[disable_rationale_key] = [join_notes(existing[i], rationale_list[i]) for i in range(len(output))]
+    else:
+        output.remove_rows(elim_bool)
     return output
 
 # delete any rows for which a required value is masked
@@ -222,7 +250,7 @@ def check_flags(table):
     new = table.copy()
     for flag in movemask.names():
         fail_list = [movemask[flag] & value for value in new['FLAGS']]
-        new = _eliminate_rows(new, fail_list, f'flag {flag}')
+        new = _eliminate_rows(new, fail_list, f'flag {flag}', mark=uargs.set_enabling)
     return new
 
 def check_static_fit_bounds(table, tighten_factor):
@@ -247,7 +275,7 @@ def check_static_fit_bounds(table, tighten_factor):
         for key, limit in limits.items():
             op = operators[key]
             fail_list = op(new[param], limit)
-            new = _eliminate_rows(new, fail_list, f'{param} {key} bound = {limit}')
+            new = _eliminate_rows(new, fail_list, f'{param} {key} bound = {limit}', mark=uargs.set_enabling)
     return new
 
 def check_xy_offsets(table, tol):
@@ -341,7 +369,7 @@ def check_num_outliers(table, tol, key):
     num_outliers_key = f'NUM_OUTLIERS_{key}'
     new[num_outliers_key] = new['NUM_POINTS'] - new[num_points_in_fit_key]
     exceeds_tol = new[num_outliers_key] > tol
-    new = _eliminate_rows(new, exceeds_tol, f'number of outliers > {tol}')
+    new = _eliminate_rows(new, exceeds_tol, f'number of outliers > {tol}', mark=uargs.set_enabling)
     return new
 
 def check_recent_rehome(table):

--- a/bin/prepare_posparams_for_instr
+++ b/bin/prepare_posparams_for_instr
@@ -556,7 +556,7 @@ for key, commit_key in commit_keys.items():
                 msg = f'This will set the field {commit_key} to True or False, for ' + \
                       ' all remaining positioners in the parameters table'
                 if uargs.set_enabling:
-                    msg += '. All {elim_action_str} positioners will have {commit_key} forced to False.'
+                    msg += f'. All {elim_action_str} positioners will have {commit_key} forced to False.'
                 else:
                     msg += ' (after the checks which were just completed).'
                 msg += ' We are not sending anything to the database at this time. We are only' + \

--- a/bin/prepare_posparams_for_instr
+++ b/bin/prepare_posparams_for_instr
@@ -445,7 +445,7 @@ class Check(object):
         output = self.func(table=table, **self.kwargs)
         n_deleted = len(table) - len(output)
         done_note = f'{self.name}: done. '
-        if uargs.set_enabling:
+        if not uargs.set_enabling:
             if n_deleted:
                 done_note += f'{n_deleted} rows deleted'
             else:

--- a/bin/prepare_posparams_for_instr
+++ b/bin/prepare_posparams_for_instr
@@ -578,7 +578,8 @@ for key, commit_key in commit_keys.items():
     
     # 2020-12-10 [JHS] Do *NOT* commit anything for devices we are setting as nonfunctional.
     # Because in practice these are cases where we don't trust the calibration.
-    new_table[commit_key] &= new_table[disable_key] == False
+    if disable_key not in commit_key:
+        new_table[commit_key] &= new_table[disable_key] == False
 
     delayed_log_notes += [f'{commit_key} {method} to {set_val} for all positioners']
     will_commit = new_table[commit_key]

--- a/bin/prepare_posparams_for_instr
+++ b/bin/prepare_posparams_for_instr
@@ -210,11 +210,10 @@ def _eliminate_rows(table, elim, rationale):
     n_elim_posids = len(posids_eliminated)
     logger.warning(f'{n_elim_rows} of {n_rows} rows have {rationale}. These rows will be {elim_action_str} ' +
                    f'from the output table. Affected positioners are:\n{sorted(posids_eliminated)}' +
-                   f'\nTotal {elim_action_str} = {n_elim_posids}\nThis leaves {len(posids_remaining)} of ' +
-                   '{len(all_posids)} positioners remaining.')
+                   f'\nTotal {elim_action_str} = {n_elim_posids}' +
+                   f'\nNot {elim_action_str} = {len(posids_remaining)}')
     output = table.copy()    
     if uargs.set_enabling:
-        assert len()
         output[disable_key] |= elim_bool
         existing = output[disable_rationale_key].tolist()
         output[disable_rationale_key] = [join_notes(existing[i], rationale) if elim_bool else existing[i] for i in range(len(output))]

--- a/bin/prepare_posparams_for_instr
+++ b/bin/prepare_posparams_for_instr
@@ -208,17 +208,21 @@ def _eliminate_rows(table, elim, rationale):
     n_rows = len(table)
     n_elim_rows = len(np.flatnonzero(elim_bool))  # flatnonzero is like argwhere but better
     n_elim_posids = len(posids_eliminated)
-    logger.warning(f'{n_elim_rows} of {n_rows} rows have {rationale}. These rows will be {elim_action_str} ' +
-                   f'from the output table. Affected positioners are:\n{sorted(posids_eliminated)}' +
-                   f'\nTotal {elim_action_str} = {n_elim_posids}' +
-                   f'\nNot {elim_action_str} = {len(posids_remaining)}')
+    msg = f'{n_elim_rows} of {n_rows} rows have {rationale}. These rows will be {elim_action_str} ' + \
+          f'from the output table. Affected positioners are:\n{sorted(posids_eliminated)}' + \
+          f'\nTotal {elim_action_str} = {n_elim_posids}' + \
+          f'\nNot {elim_action_str} = {len(posids_remaining)}' + \
+          f'\nCurrent total {elim_action_str} = '
     output = table.copy()    
     if uargs.set_enabling:
         output[disable_key] |= elim_bool
         existing = output[disable_rationale_key].tolist()
         output[disable_rationale_key] = [join_notes(existing[i], rationale) if elim_bool else existing[i] for i in range(len(output))]
+        msg += str(len(np.where(output[disable_rationale_key])[0]))
     else:
         output.remove_rows(elim_bool)
+        msg += str(len(input_table) - len(output))
+    logger.warning(msg)
     return output
 
 # eliminate any rows for which a required value is masked
@@ -347,7 +351,7 @@ def check_fit_error(table, tol, key):
             logger.warning(f'Row for {new["POS_ID"][i]} removed due to {fit_err_key}={fit_errs[i]} > tol={tol}')
         new.remove_rows(failures)
     if uargs.set_enabling:
-        logger.warning(f'{len(will_disable)} positioners will have {disable_key} --> True')
+        logger.warning(f'{len(will_disable)} positioner(s) {elim_action_str} as exceeding tol.')
     return new
 
 def check_num_outliers(table, tol, key):

--- a/bin/prepare_posparams_for_instr
+++ b/bin/prepare_posparams_for_instr
@@ -336,33 +336,11 @@ def check_fit_error(table, tol, key):
     #     set_enabling ... True  --> usual behavior of eliminating rows if not within tol
     #                      False --> keep row and mark DEVICE_CLASSIFIED_NONFUNCTIONAL to
     #                                True or False depending on whether threshold was met
-    #
-    # 2020-12-10 [JHS] This function has some historical special handling for marking /
-    # eliminating rows. Better would be to fold into _eliminate_rows like all the other
-    # check functions. However there was some special line-by-line rationale string handling
-    # I had in there which I didn't want to disturb at this time.
     new = table.copy()
     fit_err_key = 'FIT_ERROR_STATIC' if 'STATIC' in key else 'FIT_ERROR_DYNAMIC'
     fit_errs = new[fit_err_key]
     failures = fit_errs > tol
-    if uargs.set_enabling:
-        new[disable_key] = failures
-        rationales = new[disable_rationale_key].tolist()  # some convoluted logic below to handle these strings, since astropy is intolerant of variable len strs
-        will_disable = set(new['POS_ID'][new[disable_key]])
-        for i in range(len(new)):
-            row = new[i]
-            sign = '>' if row[disable_key] else '<='
-            this_rationale = f'{fit_err_key}={row[fit_err_key]:.6f} {sign} tol={tol}'
-            rationales[i] = join_notes(rationales[i], this_rationale)
-            if row[disable_key]:
-                logger.warning(this_rationale)
-        new[disable_rationale_key] = rationales
-    else:
-        for i in np.flatnonzero(failures):
-            logger.warning(f'Row for {new["POS_ID"][i]} removed due to {fit_err_key}={fit_errs[i]} > tol={tol}')
-        new.remove_rows(failures)
-    if uargs.set_enabling:
-        logger.warning(f'{len(will_disable)} positioner(s) {elim_action_str} as exceeding tol.')
+    new = _eliminate_rows(new, failures, f'{fit_err_key} > tol={tol}')
     return new
 
 def check_num_outliers(table, tol, key):

--- a/bin/prepare_posparams_for_instr
+++ b/bin/prepare_posparams_for_instr
@@ -225,7 +225,7 @@ def _eliminate_rows(table, elim, rationale):
     if uargs.set_enabling:
         output[disable_key] |= elim_bool
         existing = output[disable_rationale_key].tolist()
-        output[disable_rationale_key] = [join_notes(existing[i], rationale) if elim_bool else existing[i] for i in range(len(output))]
+        output[disable_rationale_key] = [join_notes(existing[i], rationale) if elim_bool[i] else existing[i] for i in range(len(output))]
     else:
         output.remove_rows(elim_bool)
     logger.warning(f'{msg}\n{_current_total_alt_str(output)}')

--- a/bin/prepare_posparams_for_instr
+++ b/bin/prepare_posparams_for_instr
@@ -315,6 +315,20 @@ def check_fit_error(table, tol, key, set_enabling):
         new.remove_rows(failures)
     return new
 
+def check_num_outliers(table, tol, key):
+    '''Checks number of outliers that were discarded during the fit.
+        tol ... integer >= 0
+        key ... 'STATIC' or 'DYNAMIC'
+    
+    Internal details: Returns a copy of table.
+    '''
+    assert key in ['STATIC', 'DYNAMIC']
+    assert isinstance(tol, int)
+    assert 0 <= tol
+    
+    new = table.copy()
+    num_outliers_key = f'NUM_POINTS_IN_{key}'
+
 def check_recent_rehome(table):
     '''Searches for "recent rehome" criterion. This indicates that OFFSET_T and
     OFFSET_P are ok for use on instrument.

--- a/bin/prepare_posparams_for_instr
+++ b/bin/prepare_posparams_for_instr
@@ -187,13 +187,23 @@ def join_notes(*args):
     strings = (str(x) for x in args if x != '')
     return separator.join(strings)
 
-def _current_total_alt_str(table):
+def _current_total_alt_str(table, anti=False):
     '''String saying total number of rows either deleted or marked so far.'''
-    s = f'Current total {elim_action_str} = '
+    s = 'Current total '
+    if anti:
+        s += 'not '
+    s += f'{elim_action_str} = '
     if uargs.set_enabling:
-        s += str(len(np.where(table[disable_key])[0]))
+        n_marked = len(np.flatnonzero(table[disable_key]))
+        if anti:
+            s += str(len(table) - n_marked)
+        else:
+            s += str(n_marked)
     else:
-        s += str(len(input_table) - len(table))
+        if anti:
+            s += str(len(table))
+        else:
+            s += str(len(input_table) - len(table))
     return s
 
 def _eliminate_rows(table, elim, rationale):
@@ -592,5 +602,7 @@ if uargs.set_enabling:
 import os
 path = os.path.join(out_dir, output_name)
 new_table.write(path)
+logger.info(_current_total_alt_str(new_table))
+logger.info(_current_total_alt_str(new_table, anti=True))
 logger.info(f'Saved output posparams to {path}')
 logger.info(f'Saved log file to {log_path}')

--- a/bin/prepare_posparams_for_instr
+++ b/bin/prepare_posparams_for_instr
@@ -445,10 +445,11 @@ class Check(object):
         output = self.func(table=table, **self.kwargs)
         n_deleted = len(table) - len(output)
         done_note = f'{self.name}: done. '
-        if n_deleted:
-            done_note += f'{n_deleted} rows deleted'
-        else:
-            done_note += 'No rows deleted'
+        if uargs.set_enabling:
+            if n_deleted:
+                done_note += f'{n_deleted} rows deleted'
+            else:
+                done_note += 'No rows deleted'
         logger.info(f'{done_note}, {len(output)} remaining')
         return output
     

--- a/bin/prepare_posparams_for_instr
+++ b/bin/prepare_posparams_for_instr
@@ -332,13 +332,16 @@ def check_fit_error(table, tol, key):
     failures = fit_errs > tol
     if uargs.set_enabling:
         new[disable_key] = failures
+        rationales = new[disable_rationale_key].tolist()  # some convoluted logic below to handle these strings, since astropy is intolerant of variable len strs
         will_disable = set(new['POS_ID'][new[disable_key]])
-        for row in new:
-            action = f'{disable_key}={row[disable_key]} because'
+        for i in range(len(new)):
+            row = new[i]
             sign = '>' if row[disable_key] else '<='
-            row[disable_rationale_key] = f'{action} {fit_err_key}={row[fit_err_key]:.6f} {sign} tol={tol}'
+            this_rationale = f'{fit_err_key}={row[fit_err_key]:.6f} {sign} tol={tol}'
+            rationales[i] = join_notes(rationales[i], this_rationale)
             if row[disable_key]:
-                logger.warning(row[disable_rationale_key])
+                logger.warning(this_rationale)
+        new[disable_rationale_key] = rationales
     else:
         for i in np.flatnonzero(failures):
             logger.warning(f'Row for {new["POS_ID"][i]} removed due to {fit_err_key}={fit_errs[i]} > tol={tol}')
@@ -505,7 +508,7 @@ if uargs.allow_scale:
     fits_to_check += ['DYNAMIC']
 for fit_key in fits_to_check:
     checks = [Check(check_num_outliers, tol=2, key=fit_key)]
-    checks += [Check(check_fit_error, tol=fit_err_tol, key=fit_key, set_enabling=uargs.set_enabling)]
+    checks += [Check(check_fit_error, tol=fit_err_tol, key=fit_key)]
 checks += [Check(check_flags)]
 checks += [Check(check_static_fit_bounds, tighten_factor=0.001)]
 checks += [Check(check_xy_offsets, tol=0.5)]
@@ -572,6 +575,16 @@ for note in delayed_log_notes:
     logger.info(note)
 logger.info(f'Final list of the {len(posids_to_commit)} positioner(s) with any calibration' +
             f' values to be committed:\n{sorted(posids_to_commit)}')
+
+# add some extra info for DEVICE_CLASSIFIED_NONFUNCTIONAL cases that will go in DB
+if uargs.set_enabling:
+    rationales = new_table[disable_rationale_key].tolist()
+    for i in range(len(new_table)):
+        row = new_table[i]
+        if row[disable_rationale_key]:
+            action = f'{disable_key}={row[disable_key]} because '
+            rationales[i] = action + rationales[i]
+    new_table[disable_rationale_key] = rationales
 
 # export
 import os

--- a/bin/prepare_posparams_for_instr
+++ b/bin/prepare_posparams_for_instr
@@ -173,7 +173,6 @@ def str2float(s):
     except:
         return None
 
-# check functions
 def _eliminate_rows(table, elim, rationale):
     '''Logs messages and returns a copy of table, with rows identified by elim
     deleted from it.

--- a/bin/prepare_posparams_for_instr
+++ b/bin/prepare_posparams_for_instr
@@ -450,7 +450,8 @@ class Check(object):
                 done_note += f'{n_deleted} rows deleted'
             else:
                 done_note += 'No rows deleted'
-        logger.info(f'{done_note}, {len(output)} remaining')
+            done_note += f', {len(output)} remaining'
+        logger.info(done_note)
         return output
     
     def offer_adjustment(self):

--- a/bin/prepare_posparams_for_instr
+++ b/bin/prepare_posparams_for_instr
@@ -124,6 +124,7 @@ for key in new_table.columns:
 # special setup for columns related to enabling/disabling
 new_table[disable_key] = False
 new_table[disable_rationale_key] = Column(['']*len(new_table), dtype=object) # astropy hack for variable length strings!
+elim_action_str = 'marked' if uargs.set_enabling else 'excluded'
 
 # user interaction wrappers
 def input2(message):
@@ -186,15 +187,15 @@ def join_notes(*args):
     strings = (str(x) for x in args if x != '')
     return separator.join(strings)
 
-def _eliminate_rows(table, elim, rationale, mark=False):
+def _eliminate_rows(table, elim, rationale):
     '''Logs messages and returns a copy of table, with rows identified by elim
     either deleted from it or marked DEVICE_CLASSIFIED_NONFUNCTIONAL.
     
         table ... astropy table
         elim ... list of booleans saying whether to eliminate that row
                  must be same length as table
-        rationale ... string message to include in log output message, or a list
-                      of strings of same length as table
+        rationale ... string message to include in log output message for any
+                      rows with elim == True
     '''
     assert len(table) == len(elim), f'len(table)={len(table)} != len(elim)={len(elim)}'
     if not(any(elim)):
@@ -207,30 +208,21 @@ def _eliminate_rows(table, elim, rationale, mark=False):
     n_rows = len(table)
     n_elim_rows = len(np.flatnonzero(elim_bool))  # flatnonzero is like argwhere but better
     n_elim_posids = len(posids_eliminated)
-    action = 'marked' if mark else 'excluded'
-    rationale_msg = f'{n_elim_rows} of {n_rows} rows'
-    if isinstance(rationale, str):
-        rationale_msg += f' have {rationale}'
-        rationale_list = [rationale if e else '' for e in elim_bool]
-    else:
-        rationale_list = list(rationale)
-        printable_rationale = '\n'.join(rationale_list)
-        rationale_msg += f' {action} due to:\n{printable_rationale}'
-    logger.warning(rationale_msg)
-    logger.warning('These rows will be {action} from the output table. Affected positioners are:' +
-                   f'\n{sorted(posids_eliminated)}\nTotal {action} = {n_elim_posids}' +
-                   f'\nThis leaves {len(posids_remaining)} of {len(all_posids)} positioners remaining.')
+    logger.warning(f'{n_elim_rows} of {n_rows} rows have {rationale}. These rows will be {elim_action_str} ' +
+                   f'from the output table. Affected positioners are:\n{sorted(posids_eliminated)}' +
+                   f'\nTotal {elim_action_str} = {n_elim_posids}\nThis leaves {len(posids_remaining)} of ' +
+                   '{len(all_posids)} positioners remaining.')
     output = table.copy()    
-    if mark:
+    if uargs.set_enabling:
         assert len()
         output[disable_key] |= elim_bool
         existing = output[disable_rationale_key].tolist()
-        output[disable_rationale_key] = [join_notes(existing[i], rationale_list[i]) for i in range(len(output))]
+        output[disable_rationale_key] = [join_notes(existing[i], rationale) if elim_bool else existing[i] for i in range(len(output))]
     else:
         output.remove_rows(elim_bool)
     return output
 
-# delete any rows for which a required value is masked
+# eliminate any rows for which a required value is masked
 required_keys = {'POS_ID', 'FLAGS', 'DEVICE_LOC', 'NUM_POINTS', 'DATA_END_DATE',
                  'FIT_ERROR_STATIC', 'NUM_POINTS_IN_FIT_STATIC',}
 required_keys |= set(fitter.static_keys)
@@ -240,7 +232,7 @@ mask_table = new_table.mask
 masked_list = mask_table['POS_ID']
 for key in required_keys:
     masked_list |= mask_table[key]
-new_table = _eliminate_rows(new_table, masked_list, 'missing required value(s)')
+new_table = _eliminate_rows(new_table, masked_list, 'paramfits file missing required value(s)')
 
 # check functions
 def check_flags(table):
@@ -250,7 +242,7 @@ def check_flags(table):
     new = table.copy()
     for flag in movemask.names():
         fail_list = [movemask[flag] & value for value in new['FLAGS']]
-        new = _eliminate_rows(new, fail_list, f'flag {flag}', mark=uargs.set_enabling)
+        new = _eliminate_rows(new, fail_list, f'flag {flag}')
     return new
 
 def check_static_fit_bounds(table, tighten_factor):
@@ -275,7 +267,7 @@ def check_static_fit_bounds(table, tighten_factor):
         for key, limit in limits.items():
             op = operators[key]
             fail_list = op(new[param], limit)
-            new = _eliminate_rows(new, fail_list, f'{param} {key} bound = {limit}', mark=uargs.set_enabling)
+            new = _eliminate_rows(new, fail_list, f'{param} {key} bound = {limit}')
     return new
 
 def check_xy_offsets(table, tol):
@@ -297,10 +289,11 @@ def check_xy_offsets(table, tol):
             err = offset - expected
             if abs(err) > tol:
                 delete_idxs.add(i)
-                logger.warning(f'Row for {new["POS_ID"][i]} removed due to {offset_key}=' +
+                logger.warning(f'Row for {new["POS_ID"][i]} {elim_action_str} due to {offset_key}=' +
                                f'{offset:.4f} outside tol={tol} of nominal {expected:.4f} ' +
                                f'by {offset-expected:.4f}')
-    new.remove_rows(list(delete_idxs))        
+    delete_bools = [i in delete_idxs for i in range(len(new))]
+    new = _eliminate_rows(new, delete_bools, f'OFFSET_X or OFFSET_Y outside tol={tol} of nominal value')
     return new
 
 def check_arm_lengths(table, tol):
@@ -321,10 +314,11 @@ def check_arm_lengths(table, tol):
                 logger.warning(f'Row for {new["POS_ID"][i]} removed due to {key}=' +
                                f'{length:.4f} outside tol={tol} of nominal={exp:.4f}' +
                                f' by {length-exp:.4f}')
-    new.remove_rows(list(delete_idxs))        
+    delete_bools = [i in delete_idxs for i in range(len(new))]
+    new = _eliminate_rows(new, delete_bools, f'LENGTH_R1 or LENGTH_R2 outside tol={tol} of nominal value')       
     return new
 
-def check_fit_error(table, tol, key, set_enabling):
+def check_fit_error(table, tol, key):
     '''Checks overall goodness of fit for. Argument 'tol' is max value in rms mm.
     '''
     # Internal details:
@@ -337,7 +331,7 @@ def check_fit_error(table, tol, key, set_enabling):
     fit_err_key = 'FIT_ERROR_STATIC' if 'STATIC' in key else 'FIT_ERROR_DYNAMIC'
     fit_errs = new[fit_err_key]
     failures = fit_errs > tol
-    if set_enabling:
+    if uargs.set_enabling:
         new[disable_key] = failures
         will_disable = set(new['POS_ID'][new[disable_key]])
         for row in new:
@@ -350,7 +344,7 @@ def check_fit_error(table, tol, key, set_enabling):
         for i in np.flatnonzero(failures):
             logger.warning(f'Row for {new["POS_ID"][i]} removed due to {fit_err_key}={fit_errs[i]} > tol={tol}')
         new.remove_rows(failures)
-    if set_enabling:
+    if uargs.set_enabling:
         logger.warning(f'{len(will_disable)} positioners will have {disable_key} --> True')
     return new
 
@@ -366,10 +360,10 @@ def check_num_outliers(table, tol, key):
     assert 0 <= tol
     new = table.copy()
     num_points_in_fit_key = f'NUM_POINTS_IN_FIT_{key}'
-    num_outliers_key = f'NUM_OUTLIERS_{key}'
+    num_outliers_key = f'NUM_OUTLIERS_EXCLUDED_{key}'
     new[num_outliers_key] = new['NUM_POINTS'] - new[num_points_in_fit_key]
     exceeds_tol = new[num_outliers_key] > tol
-    new = _eliminate_rows(new, exceeds_tol, f'number of outliers > {tol}', mark=uargs.set_enabling)
+    new = _eliminate_rows(new, exceeds_tol, f'number of outliers > {tol}')
     return new
 
 def check_recent_rehome(table):


### PR DESCRIPTION
- set-enabling mode is now cleanly distinguished from the default remove-rows mode
- DEVICE_CLASSIFIED_NONFUNCTIONAL == True forces no COMMIT of any parameters for that pos
- number of outliers check now included
- default arm length tol increased from 0.4 to 0.5 mm
- improvements to docs / help strings

Example call:
```prepare_posparams_for_instr -i <mydir>/all_paramfits.csv -e```