### PR TITLE
Add routine to print groups of ambigous positioners.

### DIFF
--- a/bin/desi_print_ambigous_groups
+++ b/bin/desi_print_ambigous_groups
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+
+import argparse
+import numpy as np
+import desimeter.io
+from desimeter import match_positioners
+from astropy.io import ascii
+
+parser = argparse.ArgumentParser(
+    description="Print positioner FVC centroid <-> positioner matches.")
+parser.add_argument('fvc', type=str, help='desi_fvc_proc output')
+parser.add_argument('--calib', type=str,
+                    help='csv file with LENGTH_R1, LENGTH_R2, and POS_ID',
+                    default=None)
+parser.add_argument('--petal', type=int, help='match only specified petal',
+                    default=None)
+parser.add_argument('--plot', action='store_true', help='show plot')
+args = parser.parse_args()
+
+fvc = ascii.read(args.fvc)
+
+if args.calib is None:
+    posid = np.unique(fvc['DEVICE_ID'])
+    calib = np.zeros(len(posid),
+                     dtype=[('POS_ID', 'U20'), ('LENGTH_R1', 'f4'),
+                            ('LENGTH_R2', 'f4')])
+    calib['POS_ID'] = posid
+    calib['LENGTH_R1'] = 3
+    calib['LENGTH_R2'] = 3
+else:
+    calib = ascii.read(args.calib)
+
+metr = desimeter.io.load_metrology()
+metr = metr[metr['DEVICE_TYPE'] == 'POS']
+
+if args.petal is not None:
+    metr = metr[metr['PETAL_LOC'] == args.petal]
+    okaycentroids = np.zeros(len(fvc), dtype='bool')
+    maxlen = np.max(calib['LENGTH_R1']+calib['LENGTH_R2'])
+    mf, mm, dfm = match_positioners.match2d(
+        fvc['X_FP'], fvc['Y_FP'], metr['X_FP'], metr['Y_FP'], maxlen)
+    okaycentroids[mf] = 1
+    fvc = fvc[okaycentroids]
+
+assignment, scores, score, alternatives = match_positioners.match_positioners(
+    fvc, metr, calib, return_alternatives=True)
+match_positioners.print_groupings(fvc, metr, assignment, alternatives,
+                                  calib=calib)
+if args.plot:
+    match_positioners.plot_match(fvc, metr, assignment, alternatives)
+    from matplotlib import pyplot
+    pyplot.show()

--- a/py/desimeter/match_positioners.py
+++ b/py/desimeter/match_positioners.py
@@ -200,7 +200,7 @@ def solve_assignment(score_matrix):
     return assignment + (score,)
 
 
-def plot_match(fvc, metr, assignment, alternatives=None):
+def possible_assignments_dict(assignment, alternatives):
     possible_assignments = dict()
     if alternatives is not None:
         allassignments = np.vstack([assignment, alternatives])
@@ -212,6 +212,11 @@ def plot_match(fvc, metr, assignment, alternatives=None):
                 continue
             possible_assignments[fvcind] = (
                 possible_assignments.get(fvcind, set()) | set([metrind]))
+    return possible_assignments
+
+
+def plot_match(fvc, metr, assignment, alternatives=None):
+    possible_assignments = possible_assignments_dict(assignment, alternatives)
     from matplotlib import pyplot as p
     p.plot(fvc['X_FP'], fvc['Y_FP'], '+', label='centroids')
     p.plot(metr['X_FP'], metr['Y_FP'], 'x', label='positioner centers')
@@ -225,18 +230,9 @@ def plot_match(fvc, metr, assignment, alternatives=None):
     p.legend()
 
 
-def print_groupings(fvc, metr, assignment, alternatives, file=None, calib=None):
-    possible_assignments = dict()
-    if alternatives is not None:
-        allassignments = np.vstack([assignment, alternatives])
-    else:
-        allassignments = assignment[None, ...]
-    for a in allassignments:
-        for fvcind, metrind in enumerate(a):
-            if metrind == -1:
-                continue
-            possible_assignments[metrind] = (
-                possible_assignments.get(metrind, set()) | set([fvcind]))
+def print_groupings(fvc, metr, assignment, alternatives, file=None,
+                    calib=None):
+    possible_assignments = possible_assignments_dict(assignment, alternatives)
     metrind = np.array(list(possible_assignments.keys()))
     names = [metr['DEVICE_ID'][i] for i in metrind]
     s = np.argsort(names)

--- a/py/desimeter/match_positioners.py
+++ b/py/desimeter/match_positioners.py
@@ -1,5 +1,6 @@
 import numpy as np
 import desimeter.log
+import pdb
 
 log = desimeter.log.get_logger()
 


### PR DESCRIPTION
Used for detangling petal 0 at Kitt Peak.
Makes lists of positioner <-> centroid associations, identifying numbers of ambiguous ones, for further inspection in front-illuminated images.

Example usage:
desi_print_ambigous_groups /global/cfs/cdirs/desi/spectro/desimeter/v0006/20210101/00070311/fvc-00070311.csv --petal 0