### PR TITLE
fix desc calib sort order to asc in query cmd

### DIFF
--- a/bin/get_posmoves
+++ b/bin/get_posmoves
@@ -44,8 +44,7 @@ args  = parser.parse_args()
 # open connection
 comm = psycopg2.connect(host=args.host,port=args.port, database='desi_dev', user='desi_reader',password=args.password)
 
-order_by = 'order by time_recorded desc' # canonically order things by descending when fetching from DB, affects interpretation of "latest" below
-order_by_calib = order_by
+order_by = ' order by time_recorded desc' # canonically order things by descending when fetching from DB, affects interpretation of "latest" below
 if args.latest:
     assert args.latest > 0, f"can't get {args.latest} rows!"
     args.exposure_ids = None 
@@ -157,8 +156,7 @@ for petalid in petalids :
         if args.with_calib :
 
             # adding calib info
-            cmd = f'select {desired_fields["calib"]} from posmovedb.positioner_calibration_p{petalid} where pos_id=\'{posid}\''
-            cmd += order_by_calib 
+            cmd = f'select {desired_fields["calib"]} from posmovedb.positioner_calibration_p{petalid} where pos_id=\'{posid}\' order by time_recorded asc'
             calib=dbquery(comm,cmd)
 
             # get time stamps to match


### PR DESCRIPTION
When I implemented the "--latest" feature earlier, I erroneously added sort order "desc" to the calibration retrieval. However, previously it had been default order, which is implicitly ascending. Then the code which collates calibration data rows to move data rows was grabbing the *earliest* match rather than the *latest*, which is wrong. Thanks for Kevin for catching this behavior. Fixed now.