### PR TITLE
Use vectorized cross product.

### DIFF
--- a/py/desimeter/transform/radec2tan.py
+++ b/py/desimeter/transform/radec2tan.py
@@ -181,11 +181,8 @@ def compute_aberration(ra_eclip,dec_eclip, mjd, magnif):
     targetXYZ = getXYZ(ra_eclip,dec_eclip)
 
     if len(targetXYZ.shape) > 1 :
-        VxT   = np.zeros(targetXYZ.shape)
-        TxVxT = np.zeros(targetXYZ.shape)
-        for i in range(targetXYZ.shape[1]) :
-            VxT[:,i]=np.cross(apexXYZ[:,i], targetXYZ[:,i])
-            TxVxT[:,i]=np.cross(targetXYZ[:,i],VxT[:,i])
+        VxT = np.cross(apexXYZ, targetXYZ, axis=0)
+        TxVxT = np.cross(targetXYZ,VxT, axis=0)
     else :
        VxT       = np.cross(apexXYZ, targetXYZ)
        TxVxT     = np.cross(targetXYZ, VxT)


### PR DESCRIPTION
This PR eliminates a for loop in preference for a single vectorized numpy call.  This saves 20-30 s from each fiberassign run.  In combination with skipping QA steps and replacing yaml with json in load_focalplane, this reduces the time to get fiberassign files from something like 90 s to something like 20 s.

I still need to verify that this produces identical output.  I'll try to get to this tomorrow.  But it would very much surprise me if it did not.