### PR TITLE
address deprecation warnings; test numpy 2

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,12 +23,14 @@ jobs:
                   astropy-version: '<6.1'         # KPNO+NERSC, 2025/04
                   fitsio-version: '<2'            # latest
                   numpy-version: '<1.23'          # to keep asscalar, used by astropy
+                  scipy-version: '<1.9'           # for old numpy compatibility
 
                 - os: ubuntu-latest
                   python-version: '3.12'
                   astropy-version: '<7.0'         # KPNO+NERSC, 2025/04
                   fitsio-version: ''              # latest
                   numpy-version: '<2.3'
+                  scipy-version: ''               # latest
 
         env:
             DESIUTIL_VERSION: 3.5.0
@@ -49,6 +51,7 @@ jobs:
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
                 python -m pip install -U 'numpy${{ matrix.numpy-version }}'
+                python -m pip install -U 'scipy${{ matrix.scipy-version }}'
                 python -m pip install -U 'astropy${{ matrix.astropy-version }}'
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -46,6 +46,7 @@ jobs:
                 python -m pip install --upgrade pip setuptools wheel
                 python -m pip install pytest
                 python -m pip install -r requirements.txt
+                python -m pip install desiutil
                 python -m pip install -U 'numpy${{ matrix.numpy-version }}'
                 python -m pip install -U 'scipy${{ matrix.scipy-version }}'
                 python -m pip install -U 'astropy${{ matrix.astropy-version }}'
@@ -81,6 +82,7 @@ jobs:
                 python -m pip install --upgrade pip setuptools wheel
                 python -m pip install pytest pytest-cov coveralls
                 python -m pip install -r requirements.txt
+                python -m pip install desiutil
                 python -m pip install specutils
                 python -m pip install -U 'numpy${{ matrix.numpy-version }}'
                 python -m pip install -U 'astropy${{ matrix.astropy-version }}'

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -32,9 +32,6 @@ jobs:
                   numpy-version: '<2.3'
                   scipy-version: ''               # latest
 
-        env:
-            DESIUTIL_VERSION: 3.5.0
-
         steps:
             - name: Checkout code
               uses: actions/checkout@v2
@@ -48,7 +45,6 @@ jobs:
               run: |
                 python -m pip install --upgrade pip setuptools wheel
                 python -m pip install pytest
-                python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
                 python -m pip install -U 'numpy${{ matrix.numpy-version }}'
                 python -m pip install -U 'scipy${{ matrix.scipy-version }}'
@@ -70,8 +66,6 @@ jobs:
                 fitsio-version: ['<2']     # latest
                 numpy-version: ['<1.23']   # to keep asscalar, used by astropy
                 scipy-version: ['<1.9']           # compatibility with older NumPy
-        env:
-            DESIUTIL_VERSION: 3.5.0
 
         steps:
             - name: Checkout code
@@ -86,7 +80,6 @@ jobs:
               run: |
                 python -m pip install --upgrade pip setuptools wheel
                 python -m pip install pytest pytest-cov coveralls
-                python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
                 python -m pip install specutils
                 python -m pip install -U 'numpy${{ matrix.numpy-version }}'

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,11 +16,20 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                os: [ubuntu-latest]
-                python-version: ['3.10', '3.11']  # Py 3.10.14 as of 2025-04
-                astropy-version: ['<6.1']         # KPNO+NERSC, 2025/04
-                fitsio-version: ['<2']            # latest
-                numpy-version: ['<1.23']          # to keep asscalar, used by astropy
+              include:
+
+                - os: ubuntu-latest
+                  python-version: '3.10'          # Py 3.10.14 as of 2025-04
+                  astropy-version: '<6.1'         # KPNO+NERSC, 2025/04
+                  fitsio-version: '<2'            # latest
+                  numpy-version: '<1.23'          # to keep asscalar, used by astropy
+
+                - os: ubuntu-latest
+                  python-version: '3.12'
+                  astropy-version: '<7.0'         # KPNO+NERSC, 2025/04
+                  fitsio-version: ''              # latest
+                  numpy-version: '<2.3'
+
         env:
             DESIUTIL_VERSION: 3.5.0
 

--- a/py/desimeter/test/test_findfiducials.py
+++ b/py/desimeter/test/test_findfiducials.py
@@ -33,10 +33,10 @@ class TestFindFiducials(unittest.TestCase):
                               'X_FP_METRO', 'Y_FP_METRO'])
         spots = findfiducials(spots, input_transform=self.input_transform)
         #- All fiducial locations found
-        self.assertTrue(np.all(np.in1d(self.spots['LOCATION'], spots['LOCATION'])))
+        self.assertTrue(np.all(np.isin(self.spots['LOCATION'], spots['LOCATION'])))
 
         #- No extra locations found
-        self.assertTrue(np.all(np.in1d(spots['LOCATION'], self.spots['LOCATION'])))
+        self.assertTrue(np.all(np.isin(spots['LOCATION'], self.spots['LOCATION'])))
 
         #- FAILS: All individual pinholes found
         test_pinholes = list(zip(self.spots['LOCATION'], self.spots['PINHOLE_ID']))

--- a/py/desimeter/test/test_radec2tan.py
+++ b/py/desimeter/test/test_radec2tan.py
@@ -6,7 +6,14 @@ Test RA Dec <-> Tangent plane transformation code
 import unittest
 
 import numpy as np
-from desiutil.iers import freeze_iers
+
+# Optionally use desiutil to prevent iers downloads, if desiutil is installed
+try:
+    from desiutil.iers import freeze_iers
+except ImportError:
+    def freeze_iers():
+        pass
+
 import desimeter.transform.radec2tan as radec2tan
 
 

--- a/py/desimeter/transform/fvc2fp.py
+++ b/py/desimeter/transform/fvc2fp.py
@@ -148,7 +148,7 @@ class FVC2FP(object):
         #- trim metrology to just the ones that have spots
         fidspots_pinloc = fidspots['LOCATION']*10 + fidspots['PINHOLE_ID']
         metro_pinloc = self.metrology['LOCATION']*10 + self.metrology['PINHOLE_ID']
-        jj = np.in1d(metro_pinloc, fidspots_pinloc)
+        jj = np.isin(metro_pinloc, fidspots_pinloc)
         metrology = self.metrology[jj]
 
         #- Sort so that they match each other

--- a/py/desimeter/transform/pos2ptl.py
+++ b/py/desimeter/transform/pos2ptl.py
@@ -173,11 +173,13 @@ def loc2ext(x_loc, y_loc, r1, r2, t_offset, p_offset,
     t_ext = []
     p_ext = []
     unreachable = []
+
     for i in range(n):
-        ext_ranges = [[float(int2ext(_default_t_int_range[0], t_offset[i])),
-                       float(int2ext(_default_t_int_range[1], t_offset[i]))],
-                      [float(int2ext(_default_p_int_range[0], p_offset[i])),
-                       float(int2ext(_default_p_int_range[1], p_offset[i]))]]
+        # Note: int2ext(a,b) returns a length-1 array, not scalar
+        ext_ranges = [[float(int2ext(_default_t_int_range[0], t_offset[i])[0]),
+                       float(int2ext(_default_t_int_range[1], t_offset[i])[0])],
+                      [float(int2ext(_default_p_int_range[0], p_offset[i])[0]),
+                       float(int2ext(_default_p_int_range[1], p_offset[i])[0])]]
         tp_ext, unreach = xy2tp.xy2tp(xy=[x_loc[i], y_loc[i]],
                                      r=[r1[i], r2[i]],
                                      ranges=ext_ranges,

--- a/py/desimeter/transform/rszn_lookups.py
+++ b/py/desimeter/transform/rszn_lookups.py
@@ -19,9 +19,9 @@ extracted from DESI-0530.
 import os
 import numpy as np
 from astropy.table import Table
-from pkg_resources import resource_filename
+from importlib.resources import files
 
-data_directory = resource_filename('desimeter','data')
+data_directory = str(files('desimeter').joinpath('data'))
 lookup_file = 'focal_surface_lookup.csv'
 lookup_path = os.path.join(data_directory, lookup_file)
 table = Table.read(lookup_path, format='csv', comment='#')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-desiutil
 numpy
 scipy
 matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy<1.23
+numpy
 scipy
 matplotlib
 astropy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+desiutil
 numpy
 scipy
 matplotlib


### PR DESCRIPTION
This PR fixes #199 (pkg_resources deprecation, only partially fixed by #200) and #202 (numpy 2.0 compatibility).  Previously tests still passed, but now they pass without warnings.

Tests pass without warnings at NERSC python/3.12.11, numpy/2.2.6, fitsio/1.2.6, scipy/1.16.1.  I've also attempted to update the github actions config to test similar versions, as well as the older versions used by default at NERSC.  I see that those tests are failing that will likely need some iteration on the config; apologies in advance for the spam.