### PR TITLE
add python/3.13 astropy/7.x tests

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -36,7 +36,7 @@ jobs:
                   python-version: '3.13'
                   astropy-version: '<8.0'
                   fitsio-version: ''              # latest
-                  numpy-version: '<2.3'           # for numba compatibility
+                  numpy-version: '<3'
                   scipy-version: ''               # latest
 
         steps:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -32,6 +32,13 @@ jobs:
                   numpy-version: '<2.3'
                   scipy-version: ''               # latest
 
+                - os: ubuntu-latest
+                  python-version: '3.13'
+                  astropy-version: '<8.0'
+                  fitsio-version: ''              # latest
+                  numpy-version: '<2.3'           # for numba compatibility
+                  scipy-version: ''               # latest
+
         steps:
             - name: Checkout code
               uses: actions/checkout@v2


### PR DESCRIPTION
Add python/3.13 astropy/7.x tests to github actions. Tests pass at NERSC.